### PR TITLE
Hotfixes

### DIFF
--- a/kafe/core/fitters/nexus_fitter.py
+++ b/kafe/core/fitters/nexus_fitter.py
@@ -69,6 +69,12 @@ class NexusFitter(object):
         #              callback=None,
         #              options=None)
         self.__minimizing = False
+
+        # evaluate function one more time with the final parameters,
+        # in order to ensure the nexus is up to date
+        _par_vals = self._minimizer.parameter_values
+        self._fcn_wrapper(*_par_vals)
+
         self.__state_is_from_minimizer = True
         self.__cache_stale = True
 

--- a/kafe/core/minimizers/scipy_optimize_minimizer.py
+++ b/kafe/core/minimizers/scipy_optimize_minimizer.py
@@ -29,7 +29,7 @@ class MinimizerScipyOptimize(object):
 
         self._func_handle = function_to_minimize
         self._err_def = 1.0
-        self._tol = 0.001
+        self._tol = 1e-6
 
         # cache for calculations
         self._hessian = None

--- a/kafe/fit/indexed/container.py
+++ b/kafe/fit/indexed/container.py
@@ -97,9 +97,13 @@ class IndexedContainer(DataContainerBase):
         :rtype: int
         """
         try:
-            err_val.ndim
+            err_val.ndim   # will raise if simple float
         except AttributeError:
+            err_val = np.asarray(err_val, dtype=float)
+
+        if err_val.ndim == 0:  # if dimensionless numpy array (i.e. float64), add a dimension
             err_val = np.ones(self.size) * err_val
+
         _err = SimpleGaussianError(err_val=err_val, corr_coeff=correlation,
                                    relative=relative, reference=self._idx_data)
         # TODO: reason not to use id() here?

--- a/kafe/fit/xy/container.py
+++ b/kafe/fit/xy/container.py
@@ -194,9 +194,13 @@ class XYContainer(IndexedContainer):
         """
         _axis = self._find_axis_raise(axis)
         try:
-            err_val.ndim
+            err_val.ndim   # will raise if simple float
         except AttributeError:
+            err_val = np.asarray(err_val, dtype=float)
+
+        if err_val.ndim == 0:  # if dimensionless numpy array (i.e. float64), add a dimension
             err_val = np.ones(self.size) * err_val
+
         _err = SimpleGaussianError(err_val=err_val, corr_coeff=correlation,
                                    relative=relative, reference=self._get_data_for_axis(_axis))
         # TODO: reason not to use id() here?


### PR DESCRIPTION
These are hotfixes for several bugs I found while debugging the weird contours produced when using the `scipy` minimizer on data with `x` errors...

Apparently, `scipy.optimize.minimize` finds the correct minimum, but it evaluates the function a number of times after that (presumably to calculate the Jacobian for a sanity check). So the parameters for which the function is evaluated last are not the parameters at the minimum! Unfortunately, the `NexusFitter` assumed that was always the case (since this is true for `iminuit`)...

The update should fix this issue by setting the parameter values in the `Nexus` to the best fit values, as returned from the minimizer.

I've also set the `tolerance` to a lower value. Otherwise, `scipy.optimize` stops too early and finds a slightly different minimum than `iminuit` (they are still different, but closer for a tolerance of `1e-6` than for `1e-3`...)

The `add_simple_error` fix is unrelated, but important if you try to use a `numpy.float64` instead of a normal `float` for specifying the error value...

@JohannesGaessler Could you merge these changes in to your development branch(es) and see if they work for you? If they do, I'll merge them into master as well...