### PR TITLE
Fixed TMinuit unit tests failing due to missing import

### DIFF
--- a/kafe/core/minimizers/root_tminuit_minimizer.py
+++ b/kafe/core/minimizers/root_tminuit_minimizer.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from kafe.core.contour import ContourFactory
+import six
 try:
     from ROOT import TMinuit, Double, Long
     from ROOT import TMath  # for using ROOT's chi2prob function


### PR DESCRIPTION
On my setup unit tests related to TMinuit were failing because the global name 'six' is not defined.
Importing six fixes this issue for me.

From what I can tell the six library is for compatibility between Python 3 and Python 2.
@dsavoiu did you perhaps run the unit tests in a Python 3 environment where six is automatically imported?
In any case, please check if my change causes unit tests to fail on your setup.