### PR TITLE
Asymmetric errors

### DIFF
--- a/examples/x-errors/nonlinear_fit.py
+++ b/examples/x-errors/nonlinear_fit.py
@@ -41,7 +41,7 @@ _fit.report(asymmetric_parameter_errors=True)
 
 _plot = _fit.generate_plot()
 _plot.plot()
-_plot.show_fit_info_box(format_as_latex=True, asymmetric_errors=True)
+_plot.show_fit_info_box(format_as_latex=True, asymmetric_parameter_errors=True)
 
 _profiler = ContoursProfiler(_fit)
 _profiler.plot_profiles_contours_matrix(

--- a/examples/x-errors/nonlinear_fit.py
+++ b/examples/x-errors/nonlinear_fit.py
@@ -37,10 +37,11 @@ _fit.add_simple_error('y', _y_err)
 
 
 _fit.do_fit()
+_fit.report(asymmetric_parameter_errors=True)
 
 _plot = _fit.generate_plot()
 _plot.plot()
-_plot.show_fit_info_box(format_as_latex=True)
+_plot.show_fit_info_box(format_as_latex=True, asymmetric_errors=True)
 
 _profiler = ContoursProfiler(_fit)
 _profiler.plot_profiles_contours_matrix(

--- a/kafe2/core/fitters/nexus_fitter.py
+++ b/kafe2/core/fitters/nexus_fitter.py
@@ -141,6 +141,10 @@ class NexusFitter(object):
         return self._minimizer.parameter_errors
 
     @property
+    def asymmetric_fit_parameter_errors(self):
+        return self._minimizer.asymmetric_parameter_errors
+
+    @property
     def parameter_to_minimize_value(self):
         # if self.__cache_stale or self.__minimizing:  # allow getting fresh (non-cached) parameters while minimizing
         if self.__cache_stale:

--- a/kafe2/core/minimizers/iminuit_minimizer.py
+++ b/kafe2/core/minimizers/iminuit_minimizer.py
@@ -28,10 +28,9 @@ class MinimizerIMinuit(MinimizerBase):
             self._minimizer_param_dict["limit_" + _pn] = None
 
         self._reset()  # sets self.__iminuit and caches to None
-        self._func_handle = function_to_minimize
         self.errordef = 1.0
         self.tolerance = 0.001
-        super(MinimizerIMinuit, self).__init__()
+        super(MinimizerIMinuit, self).__init__(function_to_minimize=function_to_minimize)
 
     # -- private methods
 

--- a/kafe2/core/minimizers/iminuit_minimizer.py
+++ b/kafe2/core/minimizers/iminuit_minimizer.py
@@ -43,10 +43,9 @@ class MinimizerIMinuit(MinimizerBase):
         self._fval = None
         self._par_cov_mat = None
         self._par_cor_mat = None
-        self._par_asymm_err_dn = None
-        self._par_asymm_err_up = None
         self._fmin_struct = None
         self._pars_contour = None
+        super(MinimizerIMinuit, self)._invalidate_cache()
 
     def _get_fmin_struct(self):
         if self._fmin_struct is None:
@@ -182,7 +181,7 @@ class MinimizerIMinuit(MinimizerBase):
                 # need to hack to get initial parameter values
                 _v = _m.values
                 _pvals = [_v[pname] for pname in self.parameter_names]
-            self._par_val = tuple(_pvals)
+            self._par_val = np.array(_pvals)
         return self._par_val
 
     @property

--- a/kafe2/core/minimizers/minimizer_base.py
+++ b/kafe2/core/minimizers/minimizer_base.py
@@ -37,13 +37,10 @@ class MinimizerBase(object):
         def _profile(parameter_value):
             self.set_several(self.parameter_names, min_parameters)
             self.set(parameter_name, parameter_value)
-            #print('pre %s: %s@%s' % (parameter_name, self.function_value, self.parameter_values))
             self.fix(parameter_name)
             self.minimize()
             _fval = self.function_value
             self.release(parameter_name)
-            #print('post %s: %s@%s' % (parameter_name, _fval, self.parameter_values))
-            #print()
             return _fval - target_chi_2
 
         return brentq(f=_profile, a=low, b=high, xtol=self.tolerance)

--- a/kafe2/core/minimizers/minimizer_base.py
+++ b/kafe2/core/minimizers/minimizer_base.py
@@ -1,0 +1,95 @@
+from scipy.optimize import brentq
+
+class MinimizerBase(object):
+
+    def __init__(self):
+        self._save_state_dict = dict()
+
+    def _reset(self):
+        pass
+
+    def _save_state(self):
+        raise NotImplementedError()
+
+    def _load_state(self):
+        raise NotImplementedError()
+
+    def _calculate_asymmetric_parameter_error(self, parameter_name):
+        self.minimize()
+        self._save_state()
+        _target_chi_2 = self.function_value + 1.0
+        _min_parameters = self.parameter_values  # (1.061 -0.548)
+
+        _par_index = self.parameter_names.index(parameter_name)
+        _par_min = self.parameter_values[_par_index]
+        _par_err = self.parameter_errors[_par_index]
+
+        _cut_dn = self._find_chi_2_cut(parameter_name, _par_min - 2 * _par_err, _par_min, _target_chi_2, _min_parameters)
+        _err_dn = _par_min - _cut_dn
+
+        _cut_up = self._find_chi_2_cut(parameter_name, _par_min, _par_min + 2 * _par_err, _target_chi_2, _min_parameters)
+        _err_up = _cut_up - _par_min
+        #print(_cut_dn, _cut_up)  # expected c ~ (-1.1685, 0.0729)
+        self._load_state()
+        return _err_dn, _err_up
+
+    def _find_chi_2_cut(self, parameter_name, low, high, target_chi_2, min_parameters):
+        def _profile(parameter_value):
+            self.set_several(self.parameter_names, min_parameters)
+            self.set(parameter_name, parameter_value)
+            #print('pre %s: %s@%s' % (parameter_name, self.function_value, self.parameter_values))
+            self.fix(parameter_name)
+            self.minimize()
+            _fval = self.function_value
+            self.release(parameter_name)
+            #print('post %s: %s@%s' % (parameter_name, _fval, self.parameter_values))
+            #print()
+            return _fval - target_chi_2
+
+        return brentq(f=_profile, a=low, b=high, xtol=self.tolerance)
+
+    @property
+    def function_value(self):
+        raise NotImplementedError()
+
+    @property
+    def asymmetric_parameter_errors(self):
+        _asymmetric_errors = (self._calculate_asymmetric_parameter_error(_par_name)
+                              for _par_name in self.parameter_names)
+        #self.minimize()
+        return _asymmetric_errors
+
+    @property
+    def parameter_values(self):
+        raise NotImplementedError()
+
+    @property
+    def parameter_errors(self):
+        raise NotImplementedError()
+
+    @property
+    def parameter_names(self):
+        raise NotImplementedError()
+
+    @property
+    def tolerance(self):
+        raise NotImplementedError()
+
+    @tolerance.setter
+    def tolerance(self, new_tol):
+        raise NotImplementedError()
+
+    def set(self, parameter_name, parameter_value):
+        raise NotImplementedError()
+
+    def set_several(self, parameter_names, parameter_values):
+        raise NotImplementedError()
+
+    def fix(self, parameter_name):
+        raise NotImplementedError()
+
+    def release(self, parameter_name):
+        raise NotImplementedError()
+
+    def minimize(self):
+        raise NotImplementedError()

--- a/kafe2/core/minimizers/minimizer_base.py
+++ b/kafe2/core/minimizers/minimizer_base.py
@@ -1,10 +1,14 @@
 import numpy as np
+import numdifftools as nd
 from scipy.optimize import brentq
+
+from kafe2.core.error import CovMat
 
 
 class MinimizerBase(object):
 
-    def __init__(self):
+    def __init__(self, function_to_minimize):
+        self._func_handle = function_to_minimize
         self._invalidate_cache()  # initializes caches with None
         self._save_state_dict = dict()
 
@@ -13,15 +17,29 @@ class MinimizerBase(object):
 
     def _invalidate_cache(self):
         self._par_asymm_err = None
+        self._hessian = None
+        self._hessian_inv = None
+        self._par_cov_mat = None
 
     def _save_state(self):
-        self._save_state_dict['asymmetric_parameter_error'] = self._par_asymm_err
+        self._save_state_dict['asymmetric_parameter_error'] = np.array(self._par_asymm_err)
+        self._save_state_dict['hessian'] = np.array(self._hessian)
+        self._save_state_dict['hessian_inv'] = np.array(self._hessian_inv)
+        self._save_state_dict['par_cov_mat'] = np.array(self._par_cov_mat)
 
     def _load_state(self):
-        self._par_asymm_err = self._save_state_dict['asymmetric_parameter_error']
+        self._par_asymm_err = np.array(self._save_state_dict['asymmetric_parameter_error'])
+        self._hessian = np.array(self._save_state_dict['hessian'])
+        self._hessian_inv = np.array(self._save_state_dict['hessian_inv'])
+        self._par_cov_mat = np.array(self._save_state_dict['par_cov_mat'])
+        self._func_wrapper_unpack_args(self.parameter_values)  # call the function to propagate the changes to the nexus
+
+    def _func_wrapper_unpack_args(self, args):
+        return self._func_handle(*args)
 
     def _calculate_asymmetric_parameter_errors(self):  # TODO max calls
         self.minimize()
+        self.parameter_errors  # call par error property so they're initialized for _save_state
         self._save_state()
         _asymm_par_errs = np.zeros(shape=self.parameter_values.shape + (2,))
         for _par_index, _par_name in enumerate(self.parameter_names):
@@ -54,8 +72,14 @@ class MinimizerBase(object):
         return brentq(f=_profile, a=low, b=high, xtol=self.tolerance)
 
     @property
+    def function_to_minimize(self):
+        return self._func_handle
+
+    @property
     def function_value(self):
-        raise NotImplementedError()
+        if self._fval is None:
+            self._fval = self._func_handle(*self.parameter_values)
+        return self._fval
 
     @property
     def num_pars(self):
@@ -86,6 +110,30 @@ class MinimizerBase(object):
     @tolerance.setter
     def tolerance(self, new_tol):
         raise NotImplementedError()
+
+    @property
+    def hessian(self):
+        if self._hessian is None:
+            self._hessian = nd.Hessian(self._func_wrapper_unpack_args)(self.parameter_values)
+        return self._hessian
+
+    @property
+    def hessian_inv(self):
+        if self._hessian_inv is None:
+            self._hessian_inv = np.linalg.inv(self.hessian)
+        return self._hessian_inv
+
+    @property
+    def cov_mat(self):
+        if self._par_cov_mat is None:
+            self._par_cov_mat = self.hessian_inv * 2.0 * self._err_def
+        return np.asmatrix(self._par_cov_mat)  # TODO change to array
+
+    @property
+    def cor_mat(self):
+        if self._par_cor_mat is None:
+            self._par_cor_mat = CovMat(self.cov_mat).cor_mat
+        return self._par_cor_mat
 
     def set(self, parameter_name, parameter_value):
         raise NotImplementedError()

--- a/kafe2/core/minimizers/minimizer_base.py
+++ b/kafe2/core/minimizers/minimizer_base.py
@@ -15,12 +15,12 @@ class MinimizerBase(object):
         self._par_asymm_err = None
 
     def _save_state(self):
-        raise NotImplementedError()
+        self._save_state_dict['asymmetric_parameter_error'] = self._par_asymm_err
 
     def _load_state(self):
-        raise NotImplementedError()
+        self._par_asymm_err = self._save_state_dict['asymmetric_parameter_error']
 
-    def _calculate_asymmetric_parameter_errors(self):
+    def _calculate_asymmetric_parameter_errors(self):  # TODO max calls
         self.minimize()
         self._save_state()
         _asymm_par_errs = np.zeros(shape=self.parameter_values.shape + (2,))
@@ -58,10 +58,8 @@ class MinimizerBase(object):
         raise NotImplementedError()
 
     @property
-    def asymmetric_parameter_errors(self):
-        if self._par_asymm_err is None:
-            self._par_asymm_err = self._calculate_asymmetric_parameter_errors()
-        return self._par_asymm_err
+    def num_pars(self):
+        raise NotImplementedError()
 
     @property
     def parameter_values(self):
@@ -70,6 +68,12 @@ class MinimizerBase(object):
     @property
     def parameter_errors(self):
         raise NotImplementedError()
+
+    @property
+    def asymmetric_parameter_errors(self):
+        if self._par_asymm_err is None:
+            self._par_asymm_err = self._calculate_asymmetric_parameter_errors()
+        return self._par_asymm_err
 
     @property
     def parameter_names(self):
@@ -95,5 +99,5 @@ class MinimizerBase(object):
     def release(self, parameter_name):
         raise NotImplementedError()
 
-    def minimize(self):
+    def minimize(self):  # TODO max calls
         raise NotImplementedError()

--- a/kafe2/core/minimizers/root_tminuit_minimizer.py
+++ b/kafe2/core/minimizers/root_tminuit_minimizer.py
@@ -51,8 +51,7 @@ class MinimizerROOTTMinuit(MinimizerBase):
         self._fval = None
         self._par_cov_mat = None
         self._par_cor_mat = None
-        self._par_asymm_err_dn = None
-        self._par_asymm_err_up = None
+        self._par_asymm_err = None
         self._fmin_struct = None
         self._pars_contour = None
 

--- a/kafe2/core/minimizers/root_tminuit_minimizer.py
+++ b/kafe2/core/minimizers/root_tminuit_minimizer.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
-from kafe2.core.contour import ContourFactory
 import six
+from .minimizer_base import MinimizerBase
+from kafe2.core.contour import ContourFactory
 try:
     from ROOT import TMinuit, Double, Long
     from ROOT import TMath  # for using ROOT's chi2prob function
@@ -17,7 +18,7 @@ class MinimizerROOTTMinuitException(Exception):
     pass
 
 
-class MinimizerROOTTMinuit(object):
+class MinimizerROOTTMinuit(MinimizerBase):
     def __init__(self,
                  parameter_names, parameter_values, parameter_errors,
                  function_to_minimize, strategy = 1):

--- a/kafe2/core/minimizers/scipy_optimize_minimizer.py
+++ b/kafe2/core/minimizers/scipy_optimize_minimizer.py
@@ -54,12 +54,14 @@ class MinimizerScipyOptimize(MinimizerBase):
         self._save_state_dict['parameter_values'] = self.parameter_values
         self._save_state_dict['parameter_errors'] = self.parameter_errors
         self._save_state_dict['function_value'] = self._fval
+        super(MinimizerScipyOptimize, self)._save_state()
 
     def _load_state(self):
         self.parameter_values = self._save_state_dict['parameter_values']
         self.parameter_errors = self._save_state_dict['parameter_errors']
         self._fval = self._save_state_dict['function_value']
         self._func_wrapper_unpack_args(self.parameter_values)  # call the function to propagate the changes to the nexus
+        super(MinimizerScipyOptimize, self)._load_state()
 
     def _get_opt_result(self):
         if self._opt_result is None:

--- a/kafe2/core/minimizers/scipy_optimize_minimizer.py
+++ b/kafe2/core/minimizers/scipy_optimize_minimizer.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from .minimizer_base import MinimizerBase
 from kafe2.core.contour import ContourFactory
 from kafe2.core.error import CovMat
 try:
@@ -13,7 +14,7 @@ import numdifftools as nd
 class MinimizerScipyOptimizeException(Exception):
     pass
 
-class MinimizerScipyOptimize(object):
+class MinimizerScipyOptimize(MinimizerBase):
     def __init__(self,
                  parameter_names, parameter_values, parameter_errors,
                  function_to_minimize, method="slsqp"):

--- a/kafe2/core/minimizers/scipy_optimize_minimizer.py
+++ b/kafe2/core/minimizers/scipy_optimize_minimizer.py
@@ -46,14 +46,20 @@ class MinimizerScipyOptimize(MinimizerBase):
         self._pars_contour = None
 
         self._opt_result = None
+        super(MinimizerScipyOptimize, self).__init__()
 
     # -- private methods
 
     def _save_state(self):
-        pass
+        self._save_state_dict['parameter_values'] = self.parameter_values
+        self._save_state_dict['parameter_errors'] = self.parameter_errors
+        self._save_state_dict['function_value'] = self._fval
 
     def _load_state(self):
-        pass
+        self.parameter_values = self._save_state_dict['parameter_values']
+        self.parameter_errors = self._save_state_dict['parameter_errors']
+        self._fval = self._save_state_dict['function_value']
+        self._func_wrapper_unpack_args(self.parameter_values)  # call the function to propagate the changes to the nexus
 
     def _get_opt_result(self):
         if self._opt_result is None:
@@ -71,7 +77,6 @@ class MinimizerScipyOptimize(MinimizerBase):
         assert err_def > 0
         self._err_def = err_def
 
-
     @property
     def tolerance(self):
         return self._tol
@@ -80,9 +85,6 @@ class MinimizerScipyOptimize(MinimizerBase):
     def tolerance(self, tolerance):
         assert tolerance > 0
         self._tol = tolerance
-
-
-
 
     @property
     def hessian(self):
@@ -109,7 +111,7 @@ class MinimizerScipyOptimize(MinimizerBase):
 
     @property
     def parameter_values(self):
-        return self._par_val
+        return np.array(self._par_val)
 
     @parameter_values.setter
     def parameter_values(self, new_values):
@@ -117,7 +119,11 @@ class MinimizerScipyOptimize(MinimizerBase):
 
     @property
     def parameter_errors(self):
-        return self._par_err
+        return np.array(self._par_err)
+
+    @parameter_errors.setter
+    def parameter_errors(self, new_par_errs):
+        self._par_err = np.array(new_par_errs)
 
     @property
     def parameter_names(self):
@@ -141,7 +147,6 @@ class MinimizerScipyOptimize(MinimizerBase):
     def fix(self, parameter_name):
         _par_id = self._par_names.index(parameter_name)
         self._par_fixed[_par_id] = True
-
 
     def fix_several(self, parameter_names):
         for _pn in parameter_names:
@@ -221,7 +226,6 @@ class MinimizerScipyOptimize(MinimizerBase):
             self._par_cor_mat = CovMat(self._par_cov_mat).cor_mat
 
         self._fval = self._opt_result.fun
-
 
     def contour(self, parameter_name_1, parameter_name_2, sigma=1.0, **minimizer_contour_kwargs):
         _algorithm = minimizer_contour_kwargs.pop("algorithm", "heuristic_grid")
@@ -484,7 +488,6 @@ class MinimizerScipyOptimize(MinimizerBase):
         if np.min(_adjacent_points) > contour_fun:
             return np.mean(_adjacent_points)
         return -1
-    
     
     @staticmethod
     def _get_adjacent_grid_points(grid, x_0, y_0, vector_1, vector_2):

--- a/kafe2/core/minimizers/scipy_optimize_minimizer.py
+++ b/kafe2/core/minimizers/scipy_optimize_minimizer.py
@@ -58,7 +58,7 @@ class MinimizerScipyOptimize(MinimizerBase):
 
     def _load_state(self):
         self.parameter_values = self._save_state_dict['parameter_values']
-        self.parameter_errors = self._save_state_dict['parameter_errors']
+        self._par_err = self._save_state_dict['parameter_errors']
         self._fval = self._save_state_dict['function_value']
         self._func_wrapper_unpack_args(self.parameter_values)  # call the function to propagate the changes to the nexus
         super(MinimizerScipyOptimize, self)._load_state()
@@ -122,10 +122,6 @@ class MinimizerScipyOptimize(MinimizerBase):
     @property
     def parameter_errors(self):
         return np.array(self._par_err)
-
-    @parameter_errors.setter
-    def parameter_errors(self, new_par_errs):
-        self._par_err = np.array(new_par_errs)
 
     @property
     def parameter_names(self):

--- a/kafe2/fit/_base/fit.py
+++ b/kafe2/fit/_base/fit.py
@@ -510,7 +510,7 @@ class FitBase(FileIOMixin, object):
 
         return _result_dict
 
-    def report(self, output_stream=sys.stdout):
+    def report(self, output_stream=sys.stdout, asymmetric_parameter_errors=False):
         """Print a summary of the fit state and/or results."""
         _result_dict = self.get_result_dict()
 
@@ -531,13 +531,15 @@ class FitBase(FileIOMixin, object):
         output_stream.write(_indent + "Model Parameters\n")
         output_stream.write(_indent + "================\n\n")
 
+        self._update_parameter_formatters(update_asymmetric_errors=asymmetric_parameter_errors)
         for _pf in self._model_function.argument_formatters:
             output_stream.write(_indent * 2)
             output_stream.write(
                 _pf.get_formatted(with_name=True,
                                   with_value=True,
                                   with_errors=True,
-                                  format_as_latex=False)
+                                  format_as_latex=False,
+                                  asymmetric_error=asymmetric_parameter_errors)
             )
             output_stream.write('\n')
         output_stream.write('\n')

--- a/kafe2/fit/_base/fit.py
+++ b/kafe2/fit/_base/fit.py
@@ -511,7 +511,14 @@ class FitBase(FileIOMixin, object):
         return _result_dict
 
     def report(self, output_stream=sys.stdout, asymmetric_parameter_errors=False):
-        """Print a summary of the fit state and/or results."""
+        """
+        Print a summary of the fit state and/or results.
+
+        :param output_stream: the output stream to which the report should be printed
+        :type output_stream: TextIOBase
+        :param asymmetric_parameter_errors: if ``True``, use two different parameter errors for up/down directions
+        :type asymmetric_parameter_errors: bool
+        """
         _result_dict = self.get_result_dict()
 
         ###print_dict_recursive(_result_dict, output_stream)

--- a/kafe2/fit/_base/fit.py
+++ b/kafe2/fit/_base/fit.py
@@ -100,6 +100,12 @@ class FitBase(FileIOMixin, object):
             format_as_latex=False,
             with_expression=True)
 
+    def _update_parameter_formatters(self):
+        for _fpf, _pv, _pe in zip(
+                self._model_function.argument_formatters, self.parameter_values, self.parameter_errors):
+            _fpf.value = _pv
+            _fpf.error = _pe
+
     # -- public properties
 
     @abc.abstractproperty
@@ -445,10 +451,7 @@ class FitBase(FileIOMixin, object):
         if not self._data_container.has_errors:
             raise self.EXCEPTION_TYPE('Cannot perform a fit without specifying data errors first!')
         self._fitter.do_fit()
-        # update parameter formatters
-        for _fpf, _pv, _pe in zip(self._model_function.argument_formatters, self.parameter_values, self.parameter_errors):
-            _fpf.value = _pv
-            _fpf.error = _pe
+        self._update_parameter_formatters()
 
     def assign_model_function_expression(self, expression_format_string):
         """Assign a plain-text-formatted expression string to the model function."""

--- a/kafe2/fit/_base/fit.py
+++ b/kafe2/fit/_base/fit.py
@@ -100,11 +100,14 @@ class FitBase(FileIOMixin, object):
             format_as_latex=False,
             with_expression=True)
 
-    def _update_parameter_formatters(self):
+    def _update_parameter_formatters(self, update_asymmetric_errors=False):
         for _fpf, _pv, _pe in zip(
                 self._model_function.argument_formatters, self.parameter_values, self.parameter_errors):
             _fpf.value = _pv
             _fpf.error = _pe
+        if update_asymmetric_errors:
+            for _fpf, _ape in zip(self._model_function.argument_formatters, self.asymmetric_parameter_errors):
+                _fpf.asymmetric_error = _ape
 
     # -- public properties
 
@@ -165,6 +168,11 @@ class FitBase(FileIOMixin, object):
     def parameter_cor_mat(self):
         """the current parameter correlation matrix"""
         return self._fitter.fit_parameter_cor_mat
+
+    @property
+    def asymmetric_parameter_errors(self):
+        """the current asymmetric parameter uncertainties"""
+        return self._fitter.asymmetric_fit_parameter_errors
 
     @property
     def parameter_name_value_dict(self):

--- a/kafe2/fit/_base/format.py
+++ b/kafe2/fit/_base/format.py
@@ -144,9 +144,8 @@ class ModelParameterFormatter(FileIOMixin, object):
             return None
         return self._error[0]
 
-
-    def get_formatted(self, with_name=False, with_value=True, with_errors=True,
-                      n_significant_digits=2, round_value_to_error=True, format_as_latex=False):
+    def get_formatted(self, with_name=False, with_value=True, with_errors=True, n_significant_digits=2,
+                      round_value_to_error=True, asymmetric_errors=False, format_as_latex=False):
         """
         Get a formatted string representing this model parameter.
 
@@ -158,6 +157,7 @@ class ModelParameterFormatter(FileIOMixin, object):
         :param format_as_latex: if ``True``, the returned string will be formatted using LaTeX syntax
         :return: string
         """
+        # TODO update documentation
         _display_string = ""
         if with_name:
             if format_as_latex:
@@ -192,15 +192,15 @@ class ModelParameterFormatter(FileIOMixin, object):
                     _sig = int(-np.floor(_log_abs_value / np.log(10))) + n_significant_digits - 1
 
                 _display_val = round(self._value, _sig)
-                if self._error_is_asymmetric:
+                if asymmetric_errors:
                     _display_err_dn = round(self.error_down, _sig)
                     _display_err_up = round(self.error_up, _sig)
                     if format_as_latex:
-                        _display_string += "%g^{%g}_{%g}" % (_display_val, _display_err_up, _display_err_dn)
+                        _display_string += "$%g^{%g}_{%g}$" % (_display_val, _display_err_up, _display_err_dn)
                     else:
                         _display_string += "%g + %g (up) - %g (down)" % (_display_val, _display_err_up, _display_err_dn)
                 else:
-                    _display_err = round(self._error[0], _sig)
+                    _display_err = round(0.5 * (self.error_down + self.error_up), _sig)
                     if format_as_latex:
                         _display_string += r"$%g \pm %g$" % (_display_val, _display_err)
                     else:

--- a/kafe2/fit/_base/format.py
+++ b/kafe2/fit/_base/format.py
@@ -27,7 +27,7 @@ class ModelParameterFormatter(FileIOMixin, object):
 
     The formatted string is obtained by calling the :py:meth:`~ModelParameterFormatter.get_formatted` method.
     """
-    def __init__(self, name, value=None, error=None, latex_name=None):
+    def __init__(self, name, value=None, error=None, asymmetric_error=None, latex_name=None):
         """
 
         Construct a :py:obj:`Formatter` for a model function:
@@ -46,8 +46,8 @@ class ModelParameterFormatter(FileIOMixin, object):
         """
         self.value = value
 
-        self._error_is_asymmetric = False
         self.error = error
+        self.asymmetric_error = asymmetric_error
 
         self._name = name
         self._latex_name = latex_name
@@ -100,52 +100,40 @@ class ModelParameterFormatter(FileIOMixin, object):
 
     @error.setter
     def error(self, err_spec):
-        _err_spec = err_spec
-        if _err_spec is None:
-            self._error = None
-            self._error_is_asymmetric = False
-            return
-
-        try:
-            iter(_err_spec)
-        except TypeError:
-            _err_spec = (_err_spec,)
-
-        if len(_err_spec) == 2:
-            self._error = tuple(_err_spec)  # asymmetric error
-            self._error_is_asymmetric = True
-        elif len(_err_spec) == 1:
-            self._error = (_err_spec[0], _err_spec[0])  # asymmetric error
-            self._error_is_asymmetric = False
-        else:
-            raise FormatterException("Error specification not understood: %r" % (err_spec,))
+        self._error = err_spec
 
     @property
     def error_rel(self):
         """the relative parameter error (``float``/tuple of 2 ``floats``)"""
         if self._error is None:
             return None
-        if self._error_is_asymmetric:
-            return (self._error[0]/self._value, self._error[1]/self._value)
         else:
-            return self._error[0]/self._value
+            return self._error/self._value
+
+    @property
+    def asymmetric_error(self):
+        return self._asymmetric_error
+
+    @asymmetric_error.setter
+    def asymmetric_error(self, err_spec):
+        self._asymmetric_error = err_spec
 
     @property
     def error_up(self):
         """the "up" error (only for asymmetric errors)"""
-        if self._error is None:
+        if self.asymmetric_error is None:
             return None
-        return self._error[1]
+        return self.asymmetric_error[1]
 
     @property
     def error_down(self):
         """the "down" error (only for asymmetric errors)"""
-        if self._error is None:
+        if self.asymmetric_error is None:
             return None
-        return self._error[0]
+        return self.asymmetric_error[0]
 
     def get_formatted(self, with_name=False, with_value=True, with_errors=True, n_significant_digits=2,
-                      round_value_to_error=True, asymmetric_errors=False, format_as_latex=False):
+                      round_value_to_error=True, asymmetric_error=False, format_as_latex=False):
         """
         Get a formatted string representing this model parameter.
 
@@ -174,7 +162,8 @@ class ModelParameterFormatter(FileIOMixin, object):
             if self._value:
                 _log_abs_value = np.log(np.abs(self._value))
 
-            if not with_errors or self._error is None:
+            if not with_errors or (not asymmetric_error and self.error is None) or \
+                    (asymmetric_error and self.asymmetric_error is None):
                 _sig = int(-np.floor(_log_abs_value / np.log(10))) + n_significant_digits - 1
                 _display_val = round(self._value, _sig)
                 if format_as_latex:
@@ -182,7 +171,10 @@ class ModelParameterFormatter(FileIOMixin, object):
                 else:
                     _display_string += "%g" % (_display_val,)
             else:
-                _min_err = np.min(list(map(abs, self._error)))
+                if asymmetric_error:
+                    _min_err = min(abs(self.error_up), abs(self.error_down))
+                else:
+                    _min_err = self.error
                 # fallback to rounding to 10^(-1) if error is zero
                 if not _min_err or np.isnan(_min_err):
                     _min_err = 1e-1
@@ -192,7 +184,7 @@ class ModelParameterFormatter(FileIOMixin, object):
                     _sig = int(-np.floor(_log_abs_value / np.log(10))) + n_significant_digits - 1
 
                 _display_val = round(self._value, _sig)
-                if asymmetric_errors:
+                if asymmetric_error:
                     _display_err_dn = round(self.error_down, _sig)
                     _display_err_up = round(self.error_up, _sig)
                     if format_as_latex:
@@ -200,7 +192,7 @@ class ModelParameterFormatter(FileIOMixin, object):
                     else:
                         _display_string += "%g + %g (up) - %g (down)" % (_display_val, _display_err_up, _display_err_dn)
                 else:
-                    _display_err = round(0.5 * (self.error_down + self.error_up), _sig)
+                    _display_err = round(self.error, _sig)
                     if format_as_latex:
                         _display_string += r"$%g \pm %g$" % (_display_val, _display_err)
                     else:

--- a/kafe2/fit/_base/format.py
+++ b/kafe2/fit/_base/format.py
@@ -138,14 +138,22 @@ class ModelParameterFormatter(FileIOMixin, object):
         Get a formatted string representing this model parameter.
 
         :param with_name:  if ``True``, output will include the parameter name
+        :type with_name: bool
         :param with_value: if ``True``, output will include the parameter value
+        :type with_value: bool
         :param with_errors: if ``True``, output will include the parameter error/errors
+        :type with_errors: bool
         :param n_significant_digits: number of significant digits for rounding
+        :type n_significant_digits: int
         :param round_value_to_error: if ``True``, the parameter value will be rounded to the same precision as the error
+        :type round_value_to_error: bool
+        :param asymmetric_error: if ``True``, use two different errors for up/down directions
+        :type asymmetric_error: bool
         :param format_as_latex: if ``True``, the returned string will be formatted using LaTeX syntax
-        :return: string
+        :type format_as_latex: bool
+        :return: the string representation of the parameter
+        :rtype: str
         """
-        # TODO update documentation
         _display_string = ""
         if with_name:
             if format_as_latex:

--- a/kafe2/fit/_base/format.py
+++ b/kafe2/fit/_base/format.py
@@ -190,7 +190,8 @@ class ModelParameterFormatter(FileIOMixin, object):
                     if format_as_latex:
                         _display_string += "$%g^{%g}_{%g}$" % (_display_val, _display_err_up, _display_err_dn)
                     else:
-                        _display_string += "%g + %g (up) - %g (down)" % (_display_val, _display_err_up, _display_err_dn)
+                        _display_string += "%g + %g (up) - %g (down)" % (_display_val, _display_err_up,
+                                                                         abs(_display_err_dn))
                 else:
                     _display_err = round(self.error, _sig)
                     if format_as_latex:

--- a/kafe2/fit/_base/plot.py
+++ b/kafe2/fit/_base/plot.py
@@ -457,6 +457,7 @@ class PlotFigureBase(object):
             target_figure.text(_fig_ls[2] + .025, _y, _formatted_string, **kwargs)
             _y_inc_counter += 1
 
+            _pdc._fitter._update_parameter_formatters(update_asymmetric_errors=asymmetric_errors)
             for _pi, _pf in enumerate(_pdc.model_function_argument_formatters):
                 _y = _y_inc_offset - _y_inc_size * _y_inc_counter
                 _formatted_string = _pf.get_formatted(

--- a/kafe2/fit/_base/plot.py
+++ b/kafe2/fit/_base/plot.py
@@ -431,7 +431,7 @@ class PlotFigureBase(object):
             for _pt in self._defined_plot_types:
                 self._call_plot_method_for_plot_type(_spid, _pt, target_axis=self._main_plot_axes)
 
-    def _render_parameter_info_box(self, target_figure, format_as_latex, asymmetric_errors, **kwargs):
+    def _render_parameter_info_box(self, target_figure, format_as_latex, asymmetric_parameter_errors, **kwargs):
         if 'transform' not in kwargs:
             kwargs['transform'] = target_figure.transFigure
         if 'zorder' not in kwargs:
@@ -457,12 +457,12 @@ class PlotFigureBase(object):
             target_figure.text(_fig_ls[2] + .025, _y, _formatted_string, **kwargs)
             _y_inc_counter += 1
 
-            _pdc._fitter._update_parameter_formatters(update_asymmetric_errors=asymmetric_errors)
+            _pdc._fitter._update_parameter_formatters(update_asymmetric_errors=asymmetric_parameter_errors)
             for _pi, _pf in enumerate(_pdc.model_function_argument_formatters):
                 _y = _y_inc_offset - _y_inc_size * _y_inc_counter
                 _formatted_string = _pf.get_formatted(
                     with_name=True, with_value=True, with_errors=True,
-                    asymmetric_error=asymmetric_errors, format_as_latex=format_as_latex
+                    asymmetric_error=asymmetric_parameter_errors, format_as_latex=format_as_latex
                 )
                 target_figure.text(_fig_ls[2]+.05, _y, _formatted_string, **kwargs)
                 _y_inc_counter += 1
@@ -582,14 +582,16 @@ class PlotFigureBase(object):
         self._main_plot_axes.set_xlabel(kc_plot_style(self.PLOT_STYLE_CONFIG_DATA_TYPE, 'axis_labels', 'x'))
         self._main_plot_axes.set_ylabel(kc_plot_style(self.PLOT_STYLE_CONFIG_DATA_TYPE, 'axis_labels', 'y'))
 
-    def show_fit_info_box(self, format_as_latex=True, asymmetric_errors=False):
+    def show_fit_info_box(self, asymmetric_parameter_errors=False, format_as_latex=True):
         """Render text information about each plot on the figure.
 
         :param format_as_latex: if ``True``, the infobox text will be formatted as a LaTeX string
         :type format_as_latex: bool
+        :param asymmetric_parameter_errors: if ``True``, use two different parameter errors for up/down directions
+        :type asymmetric_parameter_errors: bool
         """
-        # TODO update documentation
-        self._render_parameter_info_box(self._fig, format_as_latex=format_as_latex, asymmetric_errors=asymmetric_errors)
+        self._render_parameter_info_box(self._fig, format_as_latex=format_as_latex,
+                                        asymmetric_parameter_errors=asymmetric_parameter_errors)
 
 
 class MultiPlotBase(object):

--- a/kafe2/fit/_base/plot.py
+++ b/kafe2/fit/_base/plot.py
@@ -461,7 +461,7 @@ class PlotFigureBase(object):
                 _y = _y_inc_offset - _y_inc_size * _y_inc_counter
                 _formatted_string = _pf.get_formatted(
                     with_name=True, with_value=True, with_errors=True,
-                    asymmetric_errors=asymmetric_errors, format_as_latex=format_as_latex
+                    asymmetric_error=asymmetric_errors, format_as_latex=format_as_latex
                 )
                 target_figure.text(_fig_ls[2]+.05, _y, _formatted_string, **kwargs)
                 _y_inc_counter += 1

--- a/kafe2/fit/_base/plot.py
+++ b/kafe2/fit/_base/plot.py
@@ -431,7 +431,7 @@ class PlotFigureBase(object):
             for _pt in self._defined_plot_types:
                 self._call_plot_method_for_plot_type(_spid, _pt, target_axis=self._main_plot_axes)
 
-    def _render_parameter_info_box(self, target_figure, format_as_latex, **kwargs):
+    def _render_parameter_info_box(self, target_figure, format_as_latex, asymmetric_errors, **kwargs):
         if 'transform' not in kwargs:
             kwargs['transform'] = target_figure.transFigure
         if 'zorder' not in kwargs:
@@ -459,7 +459,10 @@ class PlotFigureBase(object):
 
             for _pi, _pf in enumerate(_pdc.model_function_argument_formatters):
                 _y = _y_inc_offset - _y_inc_size * _y_inc_counter
-                _formatted_string = _pf.get_formatted(with_name=True, with_value=True, with_errors=True, format_as_latex=format_as_latex)
+                _formatted_string = _pf.get_formatted(
+                    with_name=True, with_value=True, with_errors=True,
+                    asymmetric_errors=asymmetric_errors, format_as_latex=format_as_latex
+                )
                 target_figure.text(_fig_ls[2]+.05, _y, _formatted_string, **kwargs)
                 _y_inc_counter += 1
 
@@ -578,13 +581,14 @@ class PlotFigureBase(object):
         self._main_plot_axes.set_xlabel(kc_plot_style(self.PLOT_STYLE_CONFIG_DATA_TYPE, 'axis_labels', 'x'))
         self._main_plot_axes.set_ylabel(kc_plot_style(self.PLOT_STYLE_CONFIG_DATA_TYPE, 'axis_labels', 'y'))
 
-    def show_fit_info_box(self, format_as_latex=True):
+    def show_fit_info_box(self, format_as_latex=True, asymmetric_errors=False):
         """Render text information about each plot on the figure.
 
         :param format_as_latex: if ``True``, the infobox text will be formatted as a LaTeX string
         :type format_as_latex: bool
         """
-        self._render_parameter_info_box(self._fig, format_as_latex=format_as_latex)
+        # TODO update documentation
+        self._render_parameter_info_box(self._fig, format_as_latex=format_as_latex, asymmetric_errors=asymmetric_errors)
 
 
 class MultiPlotBase(object):

--- a/kafe2/fit/indexed/fit.py
+++ b/kafe2/fit/indexed/fit.py
@@ -253,7 +253,8 @@ class IndexedFit(FitBase):
 
     def report(self, output_stream=sys.stdout,
                show_data=True,
-               show_model=True):
+               show_model=True,
+               asymmetric_parameter_errors=False):
         """Print a summary of the fit state and/or results."""
         _result_dict = self.get_result_dict()
 
@@ -309,4 +310,5 @@ class IndexedFit(FitBase):
 
             print_dict_as_table(_data_table_dict, output_stream=output_stream, indent_level=1)
 
-        super(IndexedFit, self).report(output_stream=output_stream)
+        super(IndexedFit, self).report(output_stream=output_stream,
+                                       asymmetric_parameter_errors=asymmetric_parameter_errors)

--- a/kafe2/fit/indexed/fit.py
+++ b/kafe2/fit/indexed/fit.py
@@ -255,7 +255,18 @@ class IndexedFit(FitBase):
                show_data=True,
                show_model=True,
                asymmetric_parameter_errors=False):
-        """Print a summary of the fit state and/or results."""
+        """
+        Print a summary of the fit state and/or results.
+
+        :param output_stream: the output stream to which the report should be printed
+        :type output_stream: TextIOBase
+        :param show_data: if ``True``, print out information about the data
+        :type show_data: bool
+        :param show_model: if ``True``, print out information about the parametric model
+        :type show_model: bool
+        :param asymmetric_parameter_errors: if ``True``, use two different parameter errors for up/down directions
+        :type asymmetric_parameter_errors: bool
+        """
         _result_dict = self.get_result_dict()
 
         _indent = ' ' * 4

--- a/kafe2/fit/xy/fit.py
+++ b/kafe2/fit/xy/fit.py
@@ -917,10 +917,7 @@ class XYFit(FitBase):
                 if np.abs(self.cost_function_value - _previous_cost_function_value) < _convergence_limit:
                     break
                 _previous_cost_function_value = self.cost_function_value
-            # update parameter formatters
-            for _fpf, _pv, _pe in zip(self._model_function.argument_formatters, self.parameter_values, self.parameter_errors):
-                _fpf.value = _pv
-                _fpf.error = _pe
+            self._update_parameter_formatters()
 
     def eval_model_function(self, x=None, model_parameters=None):
         """

--- a/kafe2/fit/xy/fit.py
+++ b/kafe2/fit/xy/fit.py
@@ -976,7 +976,18 @@ class XYFit(FitBase):
                show_data=True,
                show_model=True,
                asymmetric_parameter_errors=False):
-        """Print a summary of the fit state and/or results."""
+        """
+        Print a summary of the fit state and/or results.
+
+        :param output_stream: the output stream to which the report should be printed
+        :type output_stream: TextIOBase
+        :param show_data: if ``True``, print out information about the data
+        :type show_data: bool
+        :param show_model: if ``True``, print out information about the parametric model
+        :type show_model: bool
+        :param asymmetric_parameter_errors: if ``True``, use two different parameter errors for up/down directions
+        :type asymmetric_parameter_errors: bool
+        """
         _result_dict = self.get_result_dict()
 
         _indent = ' ' * 4

--- a/kafe2/fit/xy/fit.py
+++ b/kafe2/fit/xy/fit.py
@@ -974,7 +974,8 @@ class XYFit(FitBase):
 
     def report(self, output_stream=sys.stdout,
                show_data=True,
-               show_model=True):
+               show_model=True,
+               asymmetric_parameter_errors=False):
         """Print a summary of the fit state and/or results."""
         _result_dict = self.get_result_dict()
 
@@ -1047,4 +1048,4 @@ class XYFit(FitBase):
 
             print_dict_as_table(_data_table_dict, output_stream=output_stream, indent_level=1)
 
-        super(XYFit, self).report(output_stream=output_stream)
+        super(XYFit, self).report(output_stream=output_stream, asymmetric_parameter_errors=asymmetric_parameter_errors)

--- a/kafe2/fit/xy_multi/fit.py
+++ b/kafe2/fit/xy_multi/fit.py
@@ -1066,7 +1066,18 @@ class XYMultiFit(FitBase):
                show_data=True,
                show_model=True,
                asymmetric_parameter_errors=False):
-        """Print a summary of the fit state and/or results."""
+        """
+        Print a summary of the fit state and/or results.
+
+        :param output_stream: the output stream to which the report should be printed
+        :type output_stream: TextIOBase
+        :param show_data: if ``True``, print out information about the data
+        :type show_data: bool
+        :param show_model: if ``True``, print out information about the parametric model
+        :type show_model: bool
+        :param asymmetric_parameter_errors: if ``True``, use two different parameter errors for up/down directions
+        :type asymmetric_parameter_errors: bool
+        """
         #TODO _result_dict is never used. intentional?
         #_result_dict = self.get_result_dict()
 

--- a/kafe2/fit/xy_multi/fit.py
+++ b/kafe2/fit/xy_multi/fit.py
@@ -992,10 +992,7 @@ class XYMultiFit(FitBase):
                 if np.abs(self.cost_function_value - _previous_cost_function_value) < _convergence_limit:
                     break
                 _previous_cost_function_value = self.cost_function_value
-            # update parameter formatters
-            for _fpf, _pv, _pe in zip(self._model_function.argument_formatters, self.parameter_values, self.parameter_errors):
-                _fpf.value = _pv
-                _fpf.error = _pe
+            self._update_parameter_formatters()
 
     def assign_model_function_expression(self, expression_format_string, model_index):
         """Assign a plain-text-formatted expression string to the model function."""

--- a/kafe2/fit/xy_multi/fit.py
+++ b/kafe2/fit/xy_multi/fit.py
@@ -1064,7 +1064,8 @@ class XYMultiFit(FitBase):
 
     def report(self, output_stream=sys.stdout,
                show_data=True,
-               show_model=True):
+               show_model=True,
+               asymmetric_parameter_errors=False):
         """Print a summary of the fit state and/or results."""
         #TODO _result_dict is never used. intentional?
         #_result_dict = self.get_result_dict()
@@ -1141,7 +1142,8 @@ class XYMultiFit(FitBase):
 
             print_dict_as_table(_data_table_dict, output_stream=output_stream, indent_level=1)
 
-        super(XYMultiFit, self).report(output_stream=output_stream)
+        super(XYMultiFit, self).report(output_stream=output_stream,
+                                       asymmetric_parameter_errors=asymmetric_parameter_errors)
 
     def get_splice(self, data, index):
         """


### PR DESCRIPTION
While it is possible to calculate and display the profile likelihood, it is currently not possible to calculate and display/print out asymmetric parameter errors.
This PR implements that functionality.

Asymmetric errors are calculated inside the kafe2 minimizer objects.
To ensure consistent behavior between scipy, iminuit, and root this PR adds a new base class for kafe2 minimizers.
The calculation of asymmetric errors has been implemented as a method of that base class.
In particular, that method makes use of fixing parameters.
Because scipy does not support fixing parameters this functionality has been implemented in ScipyOptimizeMinimizer.

It would have been possible to alternatively calculate the asymmetric errors from the profile of a parameter.
However, I chose not to do that because that approach would yield a less accurate result at a higher computation cost (if you calculate the profile anyways it would be cheaper though).
Also, I think that the new implementation of fixing parameters for scipy can be used to speed up profile/contour calculation.

This PR changes the internal workings of ModelParameterFormatter objects.
I saw it necessary to separate the error field into two fields for the parabolic error and the asymmetric errors.
Otherwise parameter formatters would not be able to keep track of both at the same time.

Asymmetric errors are shown in the fit info box.
The visual representation has already been implemented by @dsavoiu 
fit.report also contains a kwarg for asymmetric errors

Note: The implementation of asymmetric errors has **not** been tested for root.
I tried installing it but didn't get it to work and felt that continuing would not be a good investment of my time.