### PR TITLE
Fit result saving

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ Requirements
 * `Numdifftools <https://pypi.org/project/Numdifftools/>`_
 * `SciPy <http://www.scipy.org>`_
 * `matplotlib <http://matplotlib.org>`_
+* `tabulate <https://pypi.org/project/tabulate/>`_
 
 
 Since *kafe2* relies on *matplotlib* for graphics it might be necessary to install external programs:

--- a/kafe2/core/fitters/nexus_fitter.py
+++ b/kafe2/core/fitters/nexus_fitter.py
@@ -145,6 +145,10 @@ class NexusFitter(object):
         return self._minimizer.asymmetric_parameter_errors
 
     @property
+    def asymmetric_fit_parameter_errors_if_calculated(self):
+        return self._minimizer.asymmetric_parameter_errors_if_calculated
+
+    @property
     def parameter_to_minimize_value(self):
         # if self.__cache_stale or self.__minimizing:  # allow getting fresh (non-cached) parameters while minimizing
         if self.__cache_stale:

--- a/kafe2/core/minimizers/iminuit_minimizer.py
+++ b/kafe2/core/minimizers/iminuit_minimizer.py
@@ -201,12 +201,11 @@ class MinimizerIMinuit(MinimizerBase):
             if not self._get_iminuit().is_clean_state():
                 # if the fit has been performed at least once
                 _param_struct = self._get_iminuit().get_param_states()
-                _perrs = [p.error for p in _param_struct]
+                self._par_err = np.array([p.error for p in _param_struct])
             else:
                 # need to hack to get initial parameter errors
                 _e = self._get_iminuit().errors
-                _perrs = [_e[pname] for pname in _e]
-            self._par_err = tuple(_perrs)
+                self._par_err = np.array([_e[pname] for pname in _e])
         return self._par_err
 
     @property

--- a/kafe2/core/minimizers/minimizer_base.py
+++ b/kafe2/core/minimizers/minimizer_base.py
@@ -100,6 +100,10 @@ class MinimizerBase(object):
         return self._par_asymm_err
 
     @property
+    def asymmetric_parameter_errors_if_calculated(self):
+        return self._par_asymm_err
+
+    @property
     def parameter_names(self):
         raise NotImplementedError()
 

--- a/kafe2/core/minimizers/scipy_optimize_minimizer.py
+++ b/kafe2/core/minimizers/scipy_optimize_minimizer.py
@@ -95,7 +95,6 @@ class MinimizerScipyOptimize(MinimizerBase):
     @property
     def parameter_errors(self):
         if self._par_err is None:
-            print(self.cov_mat)
             self._par_err = np.sqrt(np.diag(self.cov_mat))
         return self._par_err
 

--- a/kafe2/fit/_base/fit.py
+++ b/kafe2/fit/_base/fit.py
@@ -224,6 +224,11 @@ class FitBase(FileIOMixin, object):
         """the names of the parameters of interest, equal to ``self.parameter_names`` minus nuisance parameter names"""
         return self.parameter_names
 
+    @property
+    def did_fit(self):
+        """whether a fit was performed for the given data and model"""
+        return self._fitter.state_is_from_minimizer
+
     # -- public methods
 
     def set_parameter_values(self, **param_name_value_dict):
@@ -481,10 +486,9 @@ class FitBase(FileIOMixin, object):
 
     def get_result_dict(self):
         """Return a structured dictionary of human-readable strings characterizing the fit result."""
-        # TODO: warn if self._fitter.state_is_from_minimizer is False?
         _result_dict = OrderedDict()
 
-        _result_dict['did_fit'] = self._fitter.state_is_from_minimizer
+        _result_dict['did_fit'] = self.did_fit
 
         _cost = self.cost_function_value
         _ndf = self._cost_function.ndf

--- a/kafe2/fit/_base/fit.py
+++ b/kafe2/fit/_base/fit.py
@@ -182,7 +182,10 @@ class FitBase(FileIOMixin, object):
     @property
     def asymmetric_parameter_errors(self):
         """the current asymmetric parameter uncertainties"""
-        return self._fitter.asymmetric_fit_parameter_errors
+        if self._loaded_result_dict is not None and self._loaded_result_dict['asymmetric_parameter_errors'] is not None:
+            return self._loaded_result_dict['asymmetric_parameter_errors']
+        else:
+            return self._fitter.asymmetric_fit_parameter_errors
 
     @property
     def parameter_name_value_dict(self):
@@ -518,6 +521,11 @@ class FitBase(FileIOMixin, object):
             _result_dict['parameter_errors'] = None
             _result_dict['parameter_cor_mat'] = None
 
+        if self._loaded_result_dict is not None and self._loaded_result_dict['asymmetric_parameter_errors'] is not None:
+            _result_dict['asymmetric_parameter_errors'] = self._loaded_result_dict['asymmetric_parameter_errors']
+        else:
+            _result_dict['asymmetric_parameter_errors'] = self._fitter.asymmetric_fit_parameter_errors_if_calculated
+
         return _result_dict
 
     def report(self, output_stream=sys.stdout, asymmetric_parameter_errors=False):
@@ -587,3 +595,9 @@ class FitBase(FileIOMixin, object):
                               format_as_latex=False)
         )
         output_stream.write('\n')
+
+    def to_file(self, filename, format=None, calculate_asymmetric_errors=False):
+        """Write kafe2 object to file"""
+        if calculate_asymmetric_errors:
+            self.asymmetric_parameter_errors
+        super(FitBase, self).to_file(filename=filename, format=None)

--- a/kafe2/fit/_base/fit.py
+++ b/kafe2/fit/_base/fit.py
@@ -158,17 +158,26 @@ class FitBase(FileIOMixin, object):
     @property
     def parameter_errors(self):
         """the current parameter uncertainties"""
-        return self._fitter.fit_parameter_errors
+        if self._loaded_result_dict is not None:
+            return self._loaded_result_dict['parameter_errors']
+        else:
+            return self._fitter.fit_parameter_errors
 
     @property
     def parameter_cov_mat(self):
         """the current parameter covariance matrix"""
-        return self._fitter.fit_parameter_cov_mat
+        if self._loaded_result_dict is not None:
+            return self._loaded_result_dict['parameter_cov_mat']
+        else:
+            return self._fitter.fit_parameter_cov_mat
 
     @property
     def parameter_cor_mat(self):
         """the current parameter correlation matrix"""
-        return self._fitter.fit_parameter_cor_mat
+        if self._loaded_result_dict is not None:
+            return self._loaded_result_dict['parameter_cor_mat']
+        else:
+            return self._fitter.fit_parameter_cor_mat
 
     @property
     def asymmetric_parameter_errors(self):
@@ -228,7 +237,10 @@ class FitBase(FileIOMixin, object):
     @property
     def did_fit(self):
         """whether a fit was performed for the given data and model"""
-        return self._fitter.state_is_from_minimizer
+        if self._loaded_result_dict is not None:
+            return self._loaded_result_dict['did_fit']
+        else:
+            return self._fitter.state_is_from_minimizer
 
     # -- public methods
 
@@ -465,6 +477,7 @@ class FitBase(FileIOMixin, object):
         if not self._data_container.has_errors:
             raise self.EXCEPTION_TYPE('Cannot perform a fit without specifying data errors first!')
         self._fitter.do_fit()
+        self._loaded_result_dict = None
         self._update_parameter_formatters()
 
     def assign_model_function_expression(self, expression_format_string):

--- a/kafe2/fit/_base/fit.py
+++ b/kafe2/fit/_base/fit.py
@@ -540,7 +540,7 @@ class FitBase(FileIOMixin, object):
                 """))
 
         if not self.did_fit:
-            output_stream.write('WARNING: No fit has been performed yet. Did you forget to run do_fit()?\n\n')
+            output_stream.write('WARNING: No fit has been performed as of yet. Did you forget to run fit.do_fit()?\n\n')
 
         output_stream.write(_indent + "Model Parameters\n")
         output_stream.write(_indent + "================\n\n")

--- a/kafe2/fit/_base/model.py
+++ b/kafe2/fit/_base/model.py
@@ -100,6 +100,7 @@ class ModelFunctionBase(FileIOMixin, object):
         self._assign_model_function_argspec_and_argcount()
         self._validate_model_function_raise()
         self._assign_function_formatter()
+        self._source_code = None
         super(ModelFunctionBase, self).__init__()
         
     @classmethod
@@ -209,3 +210,10 @@ class ModelFunctionBase(FileIOMixin, object):
             new_defaults
         )
         self._model_function_argspec = _new_argspec
+
+    @property
+    def source_code(self):
+        if self._source_code is None:
+            return inspect.getsource(self.func)
+        else:
+            return self._source_code

--- a/kafe2/fit/histogram/fit.py
+++ b/kafe2/fit/histogram/fit.py
@@ -94,6 +94,7 @@ class HistFit(FitBase):
         # FIXME: nicer way than len()?
         self._cost_function.ndf = self._data_container.size - len(self._param_model.parameters)
         self._fit_param_constraints = []
+        self._loaded_result_dict = None
 
 
     # -- private methods

--- a/kafe2/fit/indexed/fit.py
+++ b/kafe2/fit/indexed/fit.py
@@ -267,8 +267,6 @@ class IndexedFit(FitBase):
         :param asymmetric_parameter_errors: if ``True``, use two different parameter errors for up/down directions
         :type asymmetric_parameter_errors: bool
         """
-        _result_dict = self.get_result_dict()
-
         _indent = ' ' * 4
 
         if show_data:

--- a/kafe2/fit/indexed/fit.py
+++ b/kafe2/fit/indexed/fit.py
@@ -80,6 +80,7 @@ class IndexedFit(FitBase):
         self._cost_function.ndf = self._data_container.size - len(self._param_model.parameters)
 
         self._fit_param_constraints = []
+        self._loaded_result_dict = None
 
 
     # -- private methods

--- a/kafe2/fit/representation/_base.py
+++ b/kafe2/fit/representation/_base.py
@@ -51,7 +51,7 @@ class DReprWriterMixin(object):
 
     def _get_preface_comment(self):
         return '# kafe2 %s %s representation written by %s on %s.\n' % (
-            self.BASE_OBJECT_TYPE_NAME,
+            self._kafe_object.__class__.__name__,
             self.DREPR_FLAVOR_NAME,
             getpass.getuser(),
             datetime.datetime.now().strftime('%d.%m.%Y, %H:%M')

--- a/kafe2/fit/representation/_base.py
+++ b/kafe2/fit/representation/_base.py
@@ -1,4 +1,6 @@
 import abc
+import getpass
+import datetime
 
 
 class DReprError(Exception):
@@ -47,9 +49,18 @@ class DReprWriterMixin(object):
         """Implement this method for the different data formats"""
         pass
 
+    def _get_preface_comment(self):
+        return '# kafe2 %s %s representation written by %s on %s.\n' % (
+            self.BASE_OBJECT_TYPE_NAME,
+            self.DREPR_FLAVOR_NAME,
+            getpass.getuser(),
+            datetime.datetime.now().strftime('%d.%m.%Y, %H:%M')
+        )
+
     def write(self):
         self._representation = self._make_representation(self._kafe_object)
         with self._ohandle as _h:
+            _h.write(self._get_preface_comment())
             _h.write(self._representation)
 
 

--- a/kafe2/fit/representation/_yaml_base.py
+++ b/kafe2/fit/representation/_yaml_base.py
@@ -28,6 +28,7 @@ class YamlWriterMixin(DReprWriterMixin):
             except IOError:
                 # if truncate not available, ignore
                 pass
+            _h.write(self._get_preface_comment())
             yaml.dump(self._yaml_doc, _h, default_flow_style=False)
 
 class YamlReaderException(Exception):

--- a/kafe2/fit/representation/fit/yaml_drepr.py
+++ b/kafe2/fit/representation/fit/yaml_drepr.py
@@ -36,7 +36,13 @@ class FitYamlWriter(YamlWriterMixin, FitDReprBase):
 
         _yaml_doc['parameter_constraints'] = [ConstraintYamlWriter._make_representation(_parameter_constraint)
                                               for _parameter_constraint in fit.parameter_constraints]
-
+        _fit_results = fit.get_result_dict_for_robots()
+        _fit_results['parameter_values'] = _fit_results['parameter_values'].tolist()
+        if _fit_results['did_fit']:
+            _fit_results['parameter_cov_mat'] = _fit_results['parameter_cov_mat'].tolist()
+            _fit_results['parameter_errors'] = _fit_results['parameter_errors'].tolist()
+            _fit_results['parameter_cor_mat'] = _fit_results['parameter_cor_mat'].tolist()
+        _yaml_doc['fit_results'] = _fit_results
         return _yaml_doc
     
 class FitYamlReader(YamlReaderMixin, FitDReprBase):
@@ -180,14 +186,15 @@ class FitYamlReader(YamlReaderMixin, FitDReprBase):
                 minimizer=_minimizer,
                 minimizer_kwargs=_minimizer_kwargs
             )
-        if _read_parametric_model:
+        if _read_parametric_model is not None:
             _fit_object._param_model = _read_parametric_model
         _constraint_yaml_list = yaml_doc.pop('parameter_constraints', None)
-        if _constraint_yaml_list:
+        if _constraint_yaml_list is not None:
             _fit_object._fit_param_constraints = [
                 ConstraintYamlReader._make_object(_constraint_yaml, parameter_names=_fit_object.poi_names)
                 for _constraint_yaml in _constraint_yaml_list
             ]
+        yaml_doc.pop('fit_results', None)
         return _fit_object, yaml_doc
     
 # register the above classes in the module-level dictionary

--- a/kafe2/fit/xy/fit.py
+++ b/kafe2/fit/xy/fit.py
@@ -87,6 +87,7 @@ class XYFit(FitBase):
         self._cost_function.ndf = self._data_container.size - len(self._param_model.parameters)
 
         self._fit_param_constraints = []
+        self._loaded_result_dict = None
 
     # -- private methods
 
@@ -919,6 +920,7 @@ class XYFit(FitBase):
                 if np.abs(self.cost_function_value - _previous_cost_function_value) < _convergence_limit:
                     break
                 _previous_cost_function_value = self.cost_function_value
+            self._loaded_result_dict = None
             self._update_parameter_formatters()
 
     def eval_model_function(self, x=None, model_parameters=None):

--- a/kafe2/fit/xy/fit.py
+++ b/kafe2/fit/xy/fit.py
@@ -783,6 +783,8 @@ class XYFit(FitBase):
     @property
     def y_error_band(self):
         """one-dimensional array representing the uncertainty band around the model function"""
+        if not self.did_fit:
+            raise XYFitException('Cannot calculate an error band without first performing a fit.')
         self._param_model.parameters = self.poi_values  # this is lazy, so just do it
         self._param_model.x = self.x_model
         if self.__cache_y_error_band is None:

--- a/kafe2/fit/xy/fit.py
+++ b/kafe2/fit/xy/fit.py
@@ -990,8 +990,6 @@ class XYFit(FitBase):
         :param asymmetric_parameter_errors: if ``True``, use two different parameter errors for up/down directions
         :type asymmetric_parameter_errors: bool
         """
-        _result_dict = self.get_result_dict()
-
         _indent = ' ' * 4
 
         if show_data:

--- a/kafe2/fit/xy/plot.py
+++ b/kafe2/fit/xy/plot.py
@@ -136,9 +136,9 @@ class XYPlotContainer(PlotContainerBase):
         :param kwargs: keyword arguments accepted by the ``matplotlib`` ``fill_between`` method
         :return: plot handle(s)
         """
-        _band_y = self._fitter.y_error_band
-        _y = self.model_y
-        if self._fitter.has_errors:
+        if self._fitter.has_errors and self._fitter.did_fit:
+            _band_y = self._fitter.y_error_band
+            _y = self.model_y
             return target_axis.fill_between(
                 self.model_x,
                 _y - _band_y, _y + _band_y,

--- a/kafe2/fit/xy_multi/fit.py
+++ b/kafe2/fit/xy_multi/fit.py
@@ -99,6 +99,7 @@ class XYMultiFit(FitBase):
         self._cost_function.ndf = self._data_container.size - len(self._param_model.parameters)
 
         self._fit_param_constraints = []
+        self._loaded_result_dict = None
 
     # -- private methods
 
@@ -992,6 +993,7 @@ class XYMultiFit(FitBase):
                 if np.abs(self.cost_function_value - _previous_cost_function_value) < _convergence_limit:
                     break
                 _previous_cost_function_value = self.cost_function_value
+            self._loaded_result_dict = None
             self._update_parameter_formatters()
 
     def assign_model_function_expression(self, expression_format_string, model_index):

--- a/kafe2/test/fit/test_representers_fit_yaml.py
+++ b/kafe2/test/fit/test_representers_fit_yaml.py
@@ -279,6 +279,33 @@ class TestHistFitYamlRepresenter(unittest.TestCase):
         #    )
         #)
 
+    def test_round_trip_save_results(self):
+        self._fit.do_fit()
+        self._roundtrip_streamwriter.write()
+        self._roundtrip_stringstream.seek(0)  # return to beginning
+        _read_fit = self._roundtrip_streamreader.read()
+        self.assertTrue(isinstance(_read_fit, HistFit))
+
+        self.assertTrue(self._fit.did_fit == _read_fit.did_fit)
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_cov_mat,
+                _read_fit.parameter_cov_mat
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_errors,
+                _read_fit.parameter_errors
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_cor_mat,
+                _read_fit.parameter_cor_mat
+            )
+        )
+
 
 TEST_FIT_INDEXED="""
 type: indexed
@@ -496,6 +523,34 @@ class TestIndexedFitYamlRepresenter(unittest.TestCase):
             )
         )
 
+    def test_round_trip_save_results(self):
+        self._fit.do_fit()
+        self._roundtrip_streamwriter.write()
+        self._roundtrip_stringstream.seek(0)  # return to beginning
+        _read_fit = self._roundtrip_streamreader.read()
+        self.assertTrue(isinstance(_read_fit, IndexedFit))
+
+        self.assertTrue(self._fit.did_fit == _read_fit.did_fit)
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_cov_mat,
+                _read_fit.parameter_cov_mat
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_errors,
+                _read_fit.parameter_errors
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_cor_mat,
+                _read_fit.parameter_cor_mat
+            )
+        )
+
+
 TEST_FIT_XY="""
 type: xy
 dataset:
@@ -678,7 +733,6 @@ class TestXYFitYamlRepresenter(unittest.TestCase):
             )
         )
 
-
     def test_round_trip_with_stringstream(self):
         self._roundtrip_streamwriter.write()
         self._roundtrip_stringstream.seek(0)  # return to beginning
@@ -712,6 +766,34 @@ class TestXYFitYamlRepresenter(unittest.TestCase):
                 _read_fit.y_model
             )
         )
+
+    def test_round_trip_save_results(self):
+        self._fit.do_fit()
+        self._roundtrip_streamwriter.write()
+        self._roundtrip_stringstream.seek(0)  # return to beginning
+        _read_fit = self._roundtrip_streamreader.read()
+        self.assertTrue(isinstance(_read_fit, XYFit))
+
+        self.assertTrue(self._fit.did_fit == _read_fit.did_fit)
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_cov_mat,
+                _read_fit.parameter_cov_mat
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_errors,
+                _read_fit.parameter_errors
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_cor_mat,
+                _read_fit.parameter_cor_mat
+            )
+        )
+
 
 TEST_FIT_XY_MULTI="""
 type: xy_multi
@@ -959,3 +1041,31 @@ class TestXYMultiFitYamlRepresenter(unittest.TestCase):
                 _read_fit.y_model
             )
         )
+
+    def test_round_trip_save_results(self):
+        self._fit.do_fit()
+        self._roundtrip_streamwriter.write()
+        self._roundtrip_stringstream.seek(0)  # return to beginning
+        _read_fit = self._roundtrip_streamreader.read()
+        self.assertTrue(isinstance(_read_fit, XYMultiFit))
+
+        self.assertTrue(self._fit.did_fit == _read_fit.did_fit)
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_cov_mat,
+                _read_fit.parameter_cov_mat
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_errors,
+                _read_fit.parameter_errors
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                self._fit.parameter_cor_mat,
+                _read_fit.parameter_cor_mat
+            )
+        )
+

--- a/kafe2/tools.py
+++ b/kafe2/tools.py
@@ -149,7 +149,6 @@ def get_compact_representation(parameter_names, parameter_values, parameter_erro
     _par_cor_strs = ['Par cor mat']
     _max_pc_str_length = max(11, 7 * (parameter_cor_mat.shape[0] - 1) - 1)
     for _i, _par_cor_row in enumerate(np.array(parameter_cor_mat)):
-        print(_par_cor_row)
         _reduced_row_str = ''
         for _j in range(_i):
             if _j > 0:

--- a/kafe2/tools.py
+++ b/kafe2/tools.py
@@ -119,58 +119,31 @@ def print_dict_as_table(dct, output_stream=sys.stdout, sep='  ', cell_format='%.
 
 
 def get_compact_representation(parameter_names, parameter_values, parameter_errors, parameter_cor_mat, line_prefix='# ',
-                               sep='  '):
+                               table_format='rst'):
     assert (len(parameter_names) == len(parameter_values) == len(parameter_errors) == parameter_cor_mat.shape[0]
             == parameter_cor_mat.shape[1])
-    _par_names = ['Par name'] + parameter_names
-    _max_pn_str_length = 8
-    for _par_name in parameter_names:
-        if len(_par_name) > _max_pn_str_length:
-            _max_pn_str_length = len(_par_name)
+    try:
+        import tabulate
+        _headers = ['Par name', 'Par val', 'Par err', 'Par cor mat']
+        _data = []
 
-    _par_val_strs = ['Par val']
-    _max_pv_str_length = 7
-    for _par_val in parameter_values:
-        _round_sig = max(2, int(-np.floor(np.log(np.abs(_par_val))/np.log(10))) + 1)
-        _par_val_str = str(round(_par_val, _round_sig))
-        _par_val_strs.append(_par_val_str)
-        if len(_par_val_str) > _max_pv_str_length:
-            _max_pv_str_length = len(_par_val_str)
+        _reduced_cor_mat = [_cor_mat_row[:_i] for _i, _cor_mat_row in enumerate(parameter_cor_mat.tolist())]
+        _cor_mat_row_strs = tabulate.tabulate(tabular_data=_reduced_cor_mat, tablefmt='plain', floatfmt='.2g').split('\n')
 
-    _par_err_strs = ['Par err']
-    _max_pe_str_length = 7
-    for _par_err in parameter_errors:
-        _round_sig = max(2, int(-np.floor(np.log(np.abs(_par_err))/np.log(10))) + 1)
-        _par_err_str = str(round(_par_err, _round_sig))
-        _par_err_strs.append(_par_err_str)
-        if len(_par_err_str) > _max_pe_str_length:
-            _max_pe_str_length = len(_par_err_str)
+        for _i, (_par_name, _par_val, _par_err, _cor_mat_row_str) in enumerate(
+                zip(parameter_names, parameter_values, parameter_errors, _cor_mat_row_strs)):
+            _row = [_par_name]
+            _sig_fig_err = max(2, -int(np.log10(np.abs(_par_err))) + 1)
+            _sig_fig_val = max(_sig_fig_err, -int(np.log10(np.abs(_par_val))) + 2)
+            _row.append(round(_par_val, _sig_fig_val))
+            _row.append(round(_par_err, _sig_fig_err))
+            _row.append(_cor_mat_row_str)
+            _data.append(_row)
 
-    _par_cor_strs = ['Par cor mat']
-    _max_pc_str_length = max(11, 7 * (parameter_cor_mat.shape[0] - 1) - 1)
-    for _i, _par_cor_row in enumerate(np.array(parameter_cor_mat)):
-        _reduced_row_str = ''
-        for _j in range(_i):
-            if _j > 0:
-                _reduced_row_str += ' '
-            _cor_ij_str = str(round(_par_cor_row[_j], 3))
-            if len(_cor_ij_str) < 6:
-                _cor_ij_str += ' ' * (6 - len(_cor_ij_str))
-            _reduced_row_str += _cor_ij_str
-        _par_cor_strs.append(_reduced_row_str)
-
-    _represenation = ''
-    for _i, (_par_name, _par_val, _par_err, _par_cor) in enumerate(
-            zip(_par_names, _par_val_strs, _par_err_strs, _par_cor_strs)):
-        if len(_par_name) < _max_pn_str_length:
-            _par_name += ' ' * (_max_pn_str_length - len(_par_name))
-        if len(_par_val) < _max_pv_str_length:
-            _par_val += ' ' * (_max_pv_str_length - len(_par_val))
-        if len(_par_err) < _max_pe_str_length:
-            _par_err += ' ' * (_max_pe_str_length - len(_par_err))
-        _represenation += line_prefix + _par_name + sep + _par_val + sep + _par_err + sep + _par_cor + '\n'
-
-        if _i == 0:
-            _represenation += (line_prefix + '=' * _max_pn_str_length + sep + '=' * _max_pv_str_length + sep
-                               + '=' * _max_pe_str_length + sep + '=' * _max_pc_str_length + '\n')
-    return _represenation
+        _representation = tabulate.tabulate(tabular_data=_data, headers=_headers, tablefmt=table_format)
+        _representation = _representation.replace('\n', '\n' + line_prefix)
+        _representation = line_prefix + _representation + '\n'
+    except ImportError:
+        _representation = '# ERROR: Could not create human-readable table for model parameters because ' \
+                          'tabulate is not installed.\n'
+    return _representation

--- a/kafe2/tools.py
+++ b/kafe2/tools.py
@@ -118,13 +118,16 @@ def print_dict_as_table(dct, output_stream=sys.stdout, sep='  ', cell_format='%.
             output_stream.write(_indent_prefix + sep.join(_row) + '\n')
 
 
-def get_compact_representation(parameter_names, parameter_values, parameter_errors, parameter_cor_mat, line_prefix='# ',
-                               table_format='rst'):
+def get_compact_representation(parameter_names, parameter_values, parameter_errors, parameter_cor_mat,
+                               asymmetric_parameter_errors=None, line_prefix='# ', table_format='rst'):
     assert (len(parameter_names) == len(parameter_values) == len(parameter_errors) == parameter_cor_mat.shape[0]
             == parameter_cor_mat.shape[1])
     try:
         import tabulate
-        _headers = ['Par name', 'Par val', 'Par err', 'Par cor mat']
+        if asymmetric_parameter_errors is None:
+            _headers = ['Par name', 'Par val', 'Par err', 'Par cor mat']
+        else:
+            _headers = ['Par name', 'Par val', 'Par err parabolic', 'Par err down', 'Par err up', 'Par cor mat']
         _data = []
 
         _reduced_cor_mat = [_cor_mat_row[:_i] for _i, _cor_mat_row in enumerate(parameter_cor_mat.tolist())]
@@ -137,6 +140,12 @@ def get_compact_representation(parameter_names, parameter_values, parameter_erro
             _sig_fig_val = max(_sig_fig_err, -int(np.log10(np.abs(_par_val))) + 2)
             _row.append(round(_par_val, _sig_fig_val))
             _row.append(round(_par_err, _sig_fig_err))
+            if asymmetric_parameter_errors is not None:
+                _err_down, _err_up = asymmetric_parameter_errors[_i]
+                _sig_fig_err_down = max(2, -int(np.log10(np.abs(_err_down))) + 1)
+                _row.append(round(_err_down, _sig_fig_err_down))
+                _sig_fig_err_up = max(2, -int(np.log10(np.abs(_err_up))) + 1)
+                _row.append(round(_err_up, _sig_fig_err_up))
             _row.append(_cor_mat_row_str)
             _data.append(_row)
 

--- a/kafe2/tools.py
+++ b/kafe2/tools.py
@@ -116,3 +116,62 @@ def print_dict_as_table(dct, output_stream=sys.stdout, sep='  ', cell_format='%.
                 except TypeError:
                     raise
             output_stream.write(_indent_prefix + sep.join(_row) + '\n')
+
+
+def get_compact_representation(parameter_names, parameter_values, parameter_errors, parameter_cor_mat, line_prefix='# ',
+                               sep='  '):
+    assert (len(parameter_names) == len(parameter_values) == len(parameter_errors) == parameter_cor_mat.shape[0]
+            == parameter_cor_mat.shape[1])
+    _par_names = ['Par name'] + parameter_names
+    _max_pn_str_length = 8
+    for _par_name in parameter_names:
+        if len(_par_name) > _max_pn_str_length:
+            _max_pn_str_length = len(_par_name)
+
+    _par_val_strs = ['Par val']
+    _max_pv_str_length = 7
+    for _par_val in parameter_values:
+        _round_sig = max(2, int(-np.floor(np.log(np.abs(_par_val))/np.log(10))) + 1)
+        _par_val_str = str(round(_par_val, _round_sig))
+        _par_val_strs.append(_par_val_str)
+        if len(_par_val_str) > _max_pv_str_length:
+            _max_pv_str_length = len(_par_val_str)
+
+    _par_err_strs = ['Par err']
+    _max_pe_str_length = 7
+    for _par_err in parameter_errors:
+        _round_sig = max(2, int(-np.floor(np.log(np.abs(_par_err))/np.log(10))) + 1)
+        _par_err_str = str(round(_par_err, _round_sig))
+        _par_err_strs.append(_par_err_str)
+        if len(_par_err_str) > _max_pe_str_length:
+            _max_pe_str_length = len(_par_err_str)
+
+    _par_cor_strs = ['Par cor mat']
+    _max_pc_str_length = max(11, 7 * (parameter_cor_mat.shape[0] - 1) - 1)
+    for _i, _par_cor_row in enumerate(np.array(parameter_cor_mat)):
+        print(_par_cor_row)
+        _reduced_row_str = ''
+        for _j in range(_i):
+            if _j > 0:
+                _reduced_row_str += ' '
+            _cor_ij_str = str(round(_par_cor_row[_j], 3))
+            if len(_cor_ij_str) < 6:
+                _cor_ij_str += ' ' * (6 - len(_cor_ij_str))
+            _reduced_row_str += _cor_ij_str
+        _par_cor_strs.append(_reduced_row_str)
+
+    _represenation = ''
+    for _i, (_par_name, _par_val, _par_err, _par_cor) in enumerate(
+            zip(_par_names, _par_val_strs, _par_err_strs, _par_cor_strs)):
+        if len(_par_name) < _max_pn_str_length:
+            _par_name += ' ' * (_max_pn_str_length - len(_par_name))
+        if len(_par_val) < _max_pv_str_length:
+            _par_val += ' ' * (_max_pv_str_length - len(_par_val))
+        if len(_par_err) < _max_pe_str_length:
+            _par_err += ' ' * (_max_pe_str_length - len(_par_err))
+        _represenation += line_prefix + _par_name + sep + _par_val + sep + _par_err + sep + _par_cor + '\n'
+
+        if _i == 0:
+            _represenation += (line_prefix + '=' * _max_pn_str_length + sep + '=' * _max_pv_str_length + sep
+                               + '=' * _max_pe_str_length + sep + '=' * _max_pc_str_length + '\n')
+    return _represenation

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,14 @@ setup(
     package_data={'kafe2': ['config/*.conf', 'config/*.yaml', 'config/*.yml', 'fit/tools/kafe2go']},
     scripts=['kafe2/fit/tools/kafe2go.py', 'kafe2/fit/tools/kafe2go'],
     test_suite='setup.discover_kafe_tests',
-    keywords = "data analysis lab courses education students physics fitting minimization",
+    keywords="data analysis lab courses education students physics fitting minimization",
     license='GPL3',
     #TODO requirement versions
     install_requires=[
         'NumPy',
         'Numdifftools',
         'Scipy',
+        'tabulate',
         'matplotlib'
     ],
     classifiers=[


### PR DESCRIPTION
This PR adds the results of kafe2 fits to the yaml documents generated by the `fit.to_file` mathod.
This comes in two parts:

* A machine-readable part embedded as a dictionary in the regular yaml document.
* A human-readable part attached to the top of the file as a comment. This comment includes information about when the file was written and by whom.

For reference, the human-readable part looks something like this:
```
# kafe2 XYFit yaml representation written by johannes on 15.05.2019, 16:19.

# Model function: damped_harmonic_oscillator(x; y_0, l, r, g, c) = <not_specified>
# Cost: 96.79
# ndf: 116
# Cost/ndf: 0.83

# ==========  =========  =========  =================================
# Par name      Par val    Par err  Par cor mat
# ==========  =========  =========  =================================
# y_0            0.598      0.003
# l             10          0.001   1.5e-06
# r              0.052      0.001   1.4e-06  -9e-08
# g              9.781      0.002   0.046     0.42     0.42
# c              0.0099     0.0002  0.79      5.9e-06  5.7e-06  0.064
# ==========  =========  =========  =================================

```

If asymmetric parameter errors have been calculated they're added to the human-readable part as well:
```
# kafe2 XYFit yaml representation written by johannes on 15.05.2019, 17:36.

# Model function: damped_harmonic_oscillator(x; y_0, l, r, g, c) = <not_specified>
# Cost: 96.79
# ndf: 116
# Cost/ndf: 0.83

# ==========  =========  ===================  ==============  ============  =================================
# Par name      Par val    Par err parabolic    Par err down    Par err up  Par cor mat
# ==========  =========  ===================  ==============  ============  =================================
# y_0            0.598                0.003          -0.003         0.003
# l             10                    0.001          -0.001         0.001   1.3e-06
# r              0.052                0.001          -0.001         0.001   1.4e-06  -8.1e-08
# g              9.781                0.002          -0.002         0.002   0.046     0.42     0.42
# c              0.0099               0.0002         -0.0002        0.0002  0.79      5.7e-06  5.8e-06  0.064
# ==========  =========  ===================  ==============  ============  =================================

```
`fit.to_file` has a keyword argument that always adds asymmetric errors if true.

To create the human-readable part the tabulate package has been added to the dependencies.
If tabulate is not installed an error message is printed instead of a table.