### PR TITLE
Set parameter limits from fit object

### DIFF
--- a/kafe2/core/fitters/nexus_fitter.py
+++ b/kafe2/core/fitters/nexus_fitter.py
@@ -177,6 +177,12 @@ class NexusFitter(object):
     def release_parameter(self, par_name):
         self._minimizer.release(par_name)
 
+    def limit_parameter(self, par_name, par_limits):
+        self._minimizer.limit(par_name, par_limits)
+
+    def unlimit_parameter(self, par_name):
+        self._minimizer.unlimit(par_name)
+
     def contour(self, parameter_name_1, parameter_name_2, sigma=1.0, **kwargs):
         if not self.__state_is_from_minimizer:
             raise NexusFitterException("To calculate a contour the do_fit method has to be called first.")

--- a/kafe2/core/minimizers/minimizer_base.py
+++ b/kafe2/core/minimizers/minimizer_base.py
@@ -157,6 +157,12 @@ class MinimizerBase(object):
     def set_several(self, parameter_names, parameter_values):
         raise NotImplementedError()
 
+    def limit(self, parameter_name, parameter_value):
+        raise NotImplementedError()
+
+    def unlimit(self, parameter_name, parameter_value):
+        raise NotImplementedError()
+
     def fix(self, parameter_name):
         raise NotImplementedError()
 

--- a/kafe2/fit/_base/fit.py
+++ b/kafe2/fit/_base/fit.py
@@ -284,6 +284,24 @@ class FitBase(FileIOMixin, object):
         """
         self._fitter.release_parameter(par_name=par_name)
 
+    def limit_parameter(self, par_name, par_limits):
+        """
+        Limit a parameter to a given range
+        :param par_name: The name of the parameter to limited
+        :type par_name: str
+        :param par_limits: The range of the parameter to be limited to
+        :type par_limits: tuple
+        """
+        self._fitter.limit_parameter(par_name, par_limits)
+
+    def unlimit_parameter(self, par_name):
+        """
+        Unlimit a parameter
+        :param par_name: The name of the parameter to unlimit
+        :type par_name: str
+        """
+        self._fitter.unlimit_parameter(par_name)
+
     def add_matrix_parameter_constraint(self, names, values, matrix, matrix_type='cov', uncertainties=None,
                                         relative=False):
         """


### PR DESCRIPTION
Add the ability to set parameter limits from the fit object. It's then passed to the minimizers.