### PR TITLE
Unit tests

### DIFF
--- a/kafe2/fit/xy_multi/fit.py
+++ b/kafe2/fit/xy_multi/fit.py
@@ -60,8 +60,6 @@ class XYMultiFit(FitBase):
         
         # set the data
         self.data = xy_data
-        # set labels according to the size of xy_data
-        self._axis_labels = [[None, None] for _ in range(xy_data.num_datasets)]
         self._minimizer = minimizer
         self._minimizer_kwargs = minimizer_kwargs
 
@@ -441,7 +439,7 @@ class XYMultiFit(FitBase):
         else:
             self._data_container = self._new_data_container(new_data, dtype=float)
         # TODO: Think of a better way when setting new data to not always delete all labels
-        self._axis_labels = [[None, None] for _ in range(new_data.num_datasets)]
+        self._axis_labels = [[None, None] for _ in range(self._data_container.num_datasets)]
 
     @property
     def axis_labels(self):

--- a/kafe2/test/fit/test_cost_functions.py
+++ b/kafe2/test/fit/test_cost_functions.py
@@ -1,6 +1,6 @@
 import numpy as np
 import unittest
-from scipy.misc import factorial
+from scipy.special import factorial
 
 from kafe2.core.constraint import GaussianSimpleParameterConstraint, GaussianMatrixParameterConstraint
 from kafe2.fit._base.cost import *

--- a/kafe2/test/fit/test_fitters_hist.py
+++ b/kafe2/test/fit/test_fitters_hist.py
@@ -11,6 +11,7 @@ from kafe2.fit.histogram.model import HistModelFunctionException
 
 
 CONFIG_PARAMETER_DEFAULT_VALUE = kc('core', 'default_initial_parameter_value')
+DEFAULT_TEST_MINIMIZER = 'scipy'
 
 
 class TestFittersHist(unittest.TestCase):
@@ -38,7 +39,7 @@ class TestFittersHist(unittest.TestCase):
         self._ref_n_entries = 100
         self._ref_params = (14., 3.)
 
-        self._ref_entries = np.array([ 11.47195963,   9.96715403,  19.90275216,  13.65225802,
+        self._ref_entries = np.array([11.47195963,   9.96715403,  19.90275216,  13.65225802,
                                     18.52670233,  17.79707059,  11.5441954 ,  18.42331074,
                                     13.3808496 ,  18.40632518,  13.21694177,  15.34569261,
                                      9.85164713,  11.56275047,  12.42687109,   9.43924719,
@@ -74,15 +75,17 @@ class TestFittersHist(unittest.TestCase):
         self.hist_fit = HistFit(data=self._ref_hist_cont,
                                 model_density_function=self.hist_model_density,
                                 cost_function=self.simple_chi2,
-                                model_density_antiderivative=self.hist_model_density_antideriv)
+                                model_density_antiderivative=self.hist_model_density_antideriv,
+                                minimizer=DEFAULT_TEST_MINIMIZER)
         self.hist_fit.add_simple_error(err_val=1.0)
         self.hist_fit_default_cost_function = HistFit(data=self._ref_hist_cont,
                                                       model_density_function=self.hist_model_density,
-                                                      model_density_antiderivative=self.hist_model_density_antideriv)
+                                                      model_density_antiderivative=self.hist_model_density_antideriv,
+                                                      minimizer=DEFAULT_TEST_MINIMIZER)
         self.hist_fit_default_cost_function.add_simple_error(err_val=1.0)
 
-        self._ref_parameter_value_estimates = [13.828005427495496, 2.6276452391799703]
-        self._ref_parameter_value_estimates_default_cost_function = [14.185468816590726, 3.0232973450410165]
+        self._ref_parameter_value_estimates = [13.82779355, 2.62031141]
+        self._ref_parameter_value_estimates_default_cost_function = [14.18443871, 3.0148702]
         self._ref_model_estimates = (self.hist_model_density_antideriv(self._ref_bin_edges[1:], *self._ref_parameter_value_estimates) -
                                      self.hist_model_density_antideriv(self._ref_bin_edges[:-1], *self._ref_parameter_value_estimates)) * self._ref_n_entries
         self._ref_model_estimates_default_cost_function = (self.hist_model_density_antideriv(self._ref_bin_edges[1:], *self._ref_parameter_value_estimates_default_cost_function) -

--- a/kafe2/test/fit/test_fitters_indexed.py
+++ b/kafe2/test/fit/test_fitters_indexed.py
@@ -9,6 +9,7 @@ from kafe2.fit.indexed.model import IndexedModelFunctionException
 
 
 CONFIG_PARAMETER_DEFAULT_VALUE = kc('core', 'default_initial_parameter_value')
+DEFAULT_TEST_MINIMIZER = 'scipy'
 
 
 class TestFittersIndexed(unittest.TestCase):
@@ -65,18 +66,20 @@ class TestFittersIndexed(unittest.TestCase):
 
         self.idx_fit = IndexedFit(data=self._ref_data_values,
                                   model_function=self.idx_model,
-                                  cost_function=self.simple_chi2)
+                                  cost_function=self.simple_chi2,
+                                  minimizer=DEFAULT_TEST_MINIMIZER)
         self.idx_fit.add_simple_error(err_val=1.0)
-        self.idx_fit_explicit_model_name_in_chi2 = IndexedFit(
-            data=self._ref_data_values,
-            model_function=self.idx_model,
-            cost_function=self.simple_chi2_explicit_model_name)
+        self.idx_fit_explicit_model_name_in_chi2 = IndexedFit(data=self._ref_data_values,
+                                                              model_function=self.idx_model,
+                                                              cost_function=self.simple_chi2_explicit_model_name,
+                                                              minimizer=DEFAULT_TEST_MINIMIZER)
         self.idx_fit_explicit_model_name_in_chi2.add_simple_error(err_val=1.0)
         self.idx_fit_default_cost_function = IndexedFit(data=self._ref_data_values,
-                                                        model_function=self.idx_model)
+                                                        model_function=self.idx_model,
+                                                        minimizer=DEFAULT_TEST_MINIMIZER)
         self.idx_fit_default_cost_function.add_simple_error(err_val=1.0)
 
-        self._ref_parameter_value_estimates = [1.1351433845831516, 2.137441531781195, 2.3405503488535118]
+        self._ref_parameter_value_estimates = [1.1351433,  2.13736919, 2.33346549]
         self._ref_model_value_estimates = self.idx_model(*self._ref_parameter_value_estimates)
 
 
@@ -94,7 +97,7 @@ class TestFittersIndexed(unittest.TestCase):
             np.allclose(
                 self.idx_fit.model,
                 self._ref_model_values,
-                rtol=1e-2
+                rtol=1e-3
             )
         )
 
@@ -114,7 +117,7 @@ class TestFittersIndexed(unittest.TestCase):
             np.allclose(
                 self.idx_fit.model,
                 self._ref_model_value_estimates,
-                rtol=1e-2
+                rtol=1e-3
             )
         )
 
@@ -174,7 +177,8 @@ class TestFittersIndexed(unittest.TestCase):
     def test_model_nodefaults(self):
         idx_fit = IndexedFit(data=self._ref_data_values,
                              model_function=self.idx_model_nodefaults,
-                             cost_function=self.simple_chi2)
+                             cost_function=self.simple_chi2,
+                             minimizer=DEFAULT_TEST_MINIMIZER)
         self.assertTrue(
             np.allclose(
                 idx_fit.parameter_values,
@@ -186,7 +190,8 @@ class TestFittersIndexed(unittest.TestCase):
     def test_model_partialdefaults(self):
         idx_fit = IndexedFit(data=self._ref_data_values,
                              model_function=self.idx_model_partialdefaults,
-                             cost_function=self.simple_chi2)
+                             cost_function=self.simple_chi2,
+                             minimizer=DEFAULT_TEST_MINIMIZER)
         self.assertTrue(
             np.allclose(
                 idx_fit.parameter_values,
@@ -197,31 +202,31 @@ class TestFittersIndexed(unittest.TestCase):
 
     def test_raise_reserved_parameter_names_in_model(self):
         with self.assertRaises(IndexedFitException):
-            idx_fit_reserved_names = IndexedFit(
-                            data=self._ref_data_values,
-                            model_function=self.idx_model_reserved_names,
-                            cost_function=self.simple_chi2)
+            idx_fit_reserved_names = IndexedFit(data=self._ref_data_values,
+                                                model_function=self.idx_model_reserved_names,
+                                                cost_function=self.simple_chi2,
+                                                minimizer=DEFAULT_TEST_MINIMIZER)
 
     def test_raise_varargs_in_model(self):
         with self.assertRaises(IndexedModelFunctionException):
-            idx_fit_reserved_names = IndexedFit(
-                            data=self._ref_data_values,
-                            model_function=self.idx_model_varargs,
-                            cost_function=self.simple_chi2)
+            idx_fit_reserved_names = IndexedFit(data=self._ref_data_values,
+                                                model_function=self.idx_model_varargs,
+                                                cost_function=self.simple_chi2,
+                                                minimizer=DEFAULT_TEST_MINIMIZER)
 
     def test_raise_varkwargs_in_model(self):
         with self.assertRaises(IndexedModelFunctionException):
-            idx_fit_reserved_names = IndexedFit(
-                            data=self._ref_data_values,
-                            model_function=self.idx_model_varkwargs,
-                            cost_function=self.simple_chi2)
+            idx_fit_reserved_names = IndexedFit(data=self._ref_data_values,
+                                                model_function=self.idx_model_varkwargs,
+                                                cost_function=self.simple_chi2,
+                                                minimizer=DEFAULT_TEST_MINIMIZER)
 
     def test_raise_varargs_and_varkwargs_in_model(self):
         with self.assertRaises(IndexedModelFunctionException):
-            idx_fit_reserved_names = IndexedFit(
-                            data=self._ref_data_values,
-                            model_function=self.idx_model_varargs_and_varkwargs,
-                            cost_function=self.simple_chi2)
+            idx_fit_reserved_names = IndexedFit(data=self._ref_data_values,
+                                                model_function=self.idx_model_varargs_and_varkwargs,
+                                                cost_function=self.simple_chi2,
+                                                minimizer=DEFAULT_TEST_MINIMIZER)
 
 class TestFittersIndexedChi2WithError(unittest.TestCase):
 
@@ -262,7 +267,8 @@ class TestFittersIndexedChi2WithError(unittest.TestCase):
 
         self.idx_fit = IndexedFit(data=self._ref_data_values,
                                   model_function=self.idx_model,
-                                  cost_function=self.chi2_with_error)
+                                  cost_function=self.chi2_with_error,
+                                  minimizer=DEFAULT_TEST_MINIMIZER)
 
         self.idx_fit.add_simple_error(self._ref_data_error,
                                       name="MyDataError", correlation=0, relative=False, reference='data')
@@ -271,7 +277,7 @@ class TestFittersIndexedChi2WithError(unittest.TestCase):
 
         self._ref_total_error = np.sqrt(self._ref_data_error ** 2 + self._ref_model_error ** 2)
 
-        self._ref_parameter_value_estimates = [1.1351433845831516, 2.137441531781195, 2.3405503488535118]
+        self._ref_parameter_value_estimates = [1.1351433, 2.13736919, 2.33346549]
         self._ref_model_value_estimates = self.idx_model(*self._ref_parameter_value_estimates)
 
     def test_get_matching_error_all_empty_dict(self):
@@ -326,7 +332,8 @@ class TestFittersIndexedChi2WithError(unittest.TestCase):
         self.idx_fit_chi2_with_cov_mat = IndexedFit(
                                   data=self._ref_data_values,
                                   model_function=self.idx_model,
-                                  cost_function=self.chi2_with_cov_mat)
+                                  cost_function=self.chi2_with_cov_mat,
+                                  minimizer=DEFAULT_TEST_MINIMIZER)
         self.idx_fit_chi2_with_cov_mat.add_simple_error(self._ref_data_error, correlation=0, relative=False, reference='data')
         self.idx_fit_chi2_with_cov_mat.do_fit()
 
@@ -379,7 +386,7 @@ class TestFittersIndexedChi2WithError(unittest.TestCase):
             np.allclose(
                 self.idx_fit.model,
                 self._ref_model_values,
-                rtol=1e-2
+                rtol=1e-3
             )
         )
 
@@ -388,7 +395,7 @@ class TestFittersIndexedChi2WithError(unittest.TestCase):
             np.allclose(
                 self.idx_fit.total_error,
                 self._ref_total_error,
-                rtol=1e-2
+                rtol=1e-3
             )
         )
 
@@ -408,7 +415,7 @@ class TestFittersIndexedChi2WithError(unittest.TestCase):
             np.allclose(
                 self.idx_fit.model,
                 self._ref_model_value_estimates,
-                rtol=1e-2
+                rtol=1e-3
             )
         )
 
@@ -418,7 +425,7 @@ class TestFittersIndexedChi2WithError(unittest.TestCase):
             np.allclose(
                 self.idx_fit.total_error,
                 self._ref_total_error,
-                rtol=1e-2
+                rtol=1e-3
             )
         )
 

--- a/kafe2/test/fit/test_fitters_xy.py
+++ b/kafe2/test/fit/test_fitters_xy.py
@@ -8,6 +8,7 @@ from kafe2.fit.xy.fit import XYFitException
 from kafe2.fit.xy.model import XYModelFunctionException
 
 CONFIG_PARAMETER_DEFAULT_VALUE = kc('core', 'default_initial_parameter_value')
+DEFAULT_TEST_MINIMIZER = 'scipy'
 
 
 class TestFittersXY(unittest.TestCase):
@@ -65,18 +66,20 @@ class TestFittersXY(unittest.TestCase):
 
         self.xy_fit = XYFit(xy_data=self._ref_xy_data,
                             model_function=self.xy_model,
-                            cost_function=self.simple_chi2)
+                            cost_function=self.simple_chi2,
+                            minimizer=DEFAULT_TEST_MINIMIZER)
         self.xy_fit.add_simple_error(axis='y', err_val=1.0)
-        self.xy_fit_explicit_model_name_in_chi2 = XYFit(
-            xy_data=self._ref_xy_data,
-            model_function=self.xy_model,
-            cost_function=self.simple_chi2_explicit_model_name)
+        self.xy_fit_explicit_model_name_in_chi2 = XYFit(xy_data=self._ref_xy_data,
+                                                        model_function=self.xy_model,
+                                                        cost_function=self.simple_chi2_explicit_model_name,
+                                                        minimizer=DEFAULT_TEST_MINIMIZER)
         self.xy_fit_explicit_model_name_in_chi2.add_simple_error(axis='y', err_val=1.0)
         self.xy_fit_default_cost_function = XYFit(xy_data=self._ref_xy_data,
-                                                  model_function=self.xy_model)
+                                                  model_function=self.xy_model,
+                                                  minimizer=DEFAULT_TEST_MINIMIZER)
 
         self.xy_fit_default_cost_function.add_simple_error(axis='y', err_val=1.0)
-        self._ref_parameter_value_estimates = [1.1351433845831516, 2.137441531781195, 2.3405503488535118]
+        self._ref_parameter_value_estimates = [1.1351433, 2.13736919, 2.33346549]
         self._ref_y_model_value_estimates = self.xy_model(self._ref_x, *self._ref_parameter_value_estimates)
 
 
@@ -174,8 +177,9 @@ class TestFittersXY(unittest.TestCase):
 
     def test_model_nodefaults(self):
         xy_fit = XYFit(xy_data=self._ref_xy_data,
-                             model_function=self.xy_model_nodefaults,
-                             cost_function=self.simple_chi2)
+                       model_function=self.xy_model_nodefaults,
+                       cost_function=self.simple_chi2,
+                       minimizer=DEFAULT_TEST_MINIMIZER)
         self.assertTrue(
             np.allclose(
                 xy_fit.parameter_values,
@@ -186,8 +190,9 @@ class TestFittersXY(unittest.TestCase):
 
     def test_model_partialdefaults(self):
         xy_fit = XYFit(xy_data=self._ref_xy_data,
-                             model_function=self.xy_model_partialdefaults,
-                             cost_function=self.simple_chi2)
+                       model_function=self.xy_model_partialdefaults,
+                       cost_function=self.simple_chi2,
+                       minimizer=DEFAULT_TEST_MINIMIZER)
         self.assertTrue(
             np.allclose(
                 xy_fit.parameter_values,
@@ -198,31 +203,32 @@ class TestFittersXY(unittest.TestCase):
 
     def test_raise_reserved_parameter_names_in_model(self):
         with self.assertRaises(XYFitException):
-            xy_fit_reserved_names = XYFit(
-                            xy_data=self._ref_xy_data,
-                            model_function=self.xy_model_reserved_names,
-                            cost_function=self.simple_chi2)
+            xy_fit_reserved_names = XYFit(xy_data=self._ref_xy_data,
+                                          model_function=self.xy_model_reserved_names,
+                                          cost_function=self.simple_chi2,
+                                          minimizer=DEFAULT_TEST_MINIMIZER)
 
     def test_raise_varargs_in_model(self):
         with self.assertRaises(XYModelFunctionException):
-            xy_fit_reserved_names = XYFit(
-                            xy_data=self._ref_xy_data,
-                            model_function=self.xy_model_varargs,
-                            cost_function=self.simple_chi2)
+            xy_fit_reserved_names = XYFit(xy_data=self._ref_xy_data,
+                                          model_function=self.xy_model_varargs,
+                                          cost_function=self.simple_chi2,
+                                          minimizer=DEFAULT_TEST_MINIMIZER)
 
     def test_raise_varkwargs_in_model(self):
         with self.assertRaises(XYModelFunctionException):
-            xy_fit_reserved_names = XYFit(
-                            xy_data=self._ref_xy_data,
-                            model_function=self.xy_model_varkwargs,
-                            cost_function=self.simple_chi2)
+            xy_fit_reserved_names = XYFit(xy_data=self._ref_xy_data,
+                                          model_function=self.xy_model_varkwargs,
+                                          cost_function=self.simple_chi2,
+                                          minimizer=DEFAULT_TEST_MINIMIZER)
 
     def test_raise_varargs_and_varkwargs_in_model(self):
         with self.assertRaises(XYModelFunctionException):
-            xy_fit_reserved_names = XYFit(
-                            xy_data=self._ref_xy_data,
-                            model_function=self.xy_model_varargs_and_varkwargs,
-                            cost_function=self.simple_chi2)
+            xy_fit_reserved_names = XYFit(xy_data=self._ref_xy_data,
+                                          model_function=self.xy_model_varargs_and_varkwargs,
+                                          cost_function=self.simple_chi2,
+                                          minimizer=DEFAULT_TEST_MINIMIZER)
+
 
 class TestFittersXYChi2WithError(unittest.TestCase):
 
@@ -262,8 +268,9 @@ class TestFittersXYChi2WithError(unittest.TestCase):
         self._ref_y_model_error = 1.0
 
         self.xy_fit = XYFit(xy_data=self._ref_xy_data,
-                                  model_function=self.xy_model,
-                                  cost_function=self.chi2_with_error)
+                            model_function=self.xy_model,
+                            cost_function=self.chi2_with_error,
+                            minimizer=DEFAULT_TEST_MINIMIZER)
 
         self.xy_fit.add_simple_error('y', self._ref_y_data_error,
                                      name="MyYDataError", correlation=0, relative=False, reference='data')
@@ -272,7 +279,7 @@ class TestFittersXYChi2WithError(unittest.TestCase):
 
         self._ref_y_total_error = np.sqrt(self._ref_y_data_error ** 2 + self._ref_y_model_error ** 2)
 
-        self._ref_parameter_value_estimates = [1.1351433845831516, 2.137441531781195, 2.3405503488535118]
+        self._ref_parameter_value_estimates = [1.1351433, 2.13736919, 2.33346549]
         self._ref_model_value_estimates = self.xy_model(self._ref_x, *self._ref_parameter_value_estimates)
 
     def test_get_matching_error_all_empty_dict(self):
@@ -333,7 +340,8 @@ class TestFittersXYChi2WithError(unittest.TestCase):
         self.xy_fit_chi2_with_cov_mat = XYFit(
                                   xy_data=self._ref_xy_data,
                                   model_function=self.xy_model,
-                                  cost_function=self.chi2_with_cov_mat)
+                                  cost_function=self.chi2_with_cov_mat,
+                                  minimizer=DEFAULT_TEST_MINIMIZER)
         self.xy_fit_chi2_with_cov_mat.add_simple_error('y', self._ref_y_data_error, correlation=0, relative=False, reference='data')
         self.xy_fit_chi2_with_cov_mat.do_fit()
 

--- a/kafe2/test/fit/test_fitters_xy_multi.py
+++ b/kafe2/test/fit/test_fitters_xy_multi.py
@@ -9,6 +9,7 @@ from kafe2.fit.xy_multi.model import XYMultiModelFunctionException
 from kafe2.fit.xy.model import XYModelFunctionException
 
 CONFIG_PARAMETER_DEFAULT_VALUE = kc('core', 'default_initial_parameter_value')
+DEFAULT_TEST_MINIMIZER = 'scipy'
 
 
 class TestFittersXYMulti(unittest.TestCase):
@@ -68,7 +69,7 @@ class TestFittersXYMulti(unittest.TestCase):
         self._ref_x = np.arange(10)
         self._ref_y_model_values_0 = self.xy_model_0(self._ref_x, *self._ref_parameter_values_0)
         self._ref_y_model_values_1 = self.xy_model_1(self._ref_x, *self._ref_parameter_values_1)
-        self._ref_data_jitter_0 = np.array([-0.3193475 , -1.2404198 , -1.4906926 , -0.78832446,
+        self._ref_data_jitter_0 = np.array([-0.3193475, -1.2404198, -1.4906926,  -0.78832446,
                                           -1.7638106,   0.36664261,  0.49433821,  0.0719646,
                                            1.95670326,  0.31200215])
         self._ref_data_jitter_1 = np.array([ 0.49671415, -0.1382643,   0.64768854,  1.52302986,
@@ -83,35 +84,40 @@ class TestFittersXYMulti(unittest.TestCase):
         self.xy_fit = XYMultiFit(
             xy_data=self._ref_xy_data_0,
             model_function=self.xy_model_0,
-            cost_function=self.simple_chi2
+            cost_function=self.simple_chi2,
+            minimizer=DEFAULT_TEST_MINIMIZER
         )
         self.xy_fit.add_simple_error(axis='y', err_val=1.0)
         self.xy_multi_fit = XYMultiFit(
             xy_data=[self._ref_xy_data_0, self._ref_xy_data_1],
             model_function=[self.xy_model_0, self.xy_model_1],
-            cost_function=self.simple_chi2
+            cost_function=self.simple_chi2,
+            minimizer=DEFAULT_TEST_MINIMIZER
         )
         self.xy_multi_fit.add_simple_error(axis='y', err_val=1.0)
         self.xy_multi_fit_reversed = XYMultiFit(
             xy_data=[self._ref_xy_data_1, self._ref_xy_data_0],
             model_function=[self.xy_model_1, self.xy_model_0],
-            cost_function=self.simple_chi2
+            cost_function=self.simple_chi2,
+            minimizer=DEFAULT_TEST_MINIMIZER
         )
         self.xy_multi_fit_reversed.add_simple_error(axis='y', err_val=1.0)
 
         self.xy_fit_explicit_model_name_in_chi2 = XYMultiFit(
             xy_data=self._ref_xy_data_0,
             model_function=self.xy_model_0,
-            cost_function=self.simple_chi2_explicit_model_name
+            cost_function=self.simple_chi2_explicit_model_name,
+            minimizer=DEFAULT_TEST_MINIMIZER
             )
         self.xy_fit_explicit_model_name_in_chi2.add_simple_error(axis='y', err_val=1.0)
         self.xy_fit_default_cost_function = XYMultiFit(xy_data=self._ref_xy_data_0,
-                                                  model_function=self.xy_model_0)
+                                                       model_function=self.xy_model_0,
+                                                       minimizer=DEFAULT_TEST_MINIMIZER)
 
         self.xy_fit_default_cost_function.add_simple_error(axis='y', err_val=1.0)
-        self._ref_parameter_value_estimates = [1.1351433845831516, 2.137441531781195, 2.3405503488535118]
-        self._ref_parameter_value_estimates_multi = [1.1143123505697918, 2.216862250281803, 2.9800759409541806, 0.4994086448422639]
-        self._ref_parameter_value_estimates_multi_reversed = [0.49940864485321074, 1.1143123504315096, 2.216862249916337, 2.9800759487215562]
+        self._ref_parameter_value_estimates = [1.1351433, 2.13736919, 2.33346549]
+        self._ref_parameter_value_estimates_multi = [1.11431227, 2.21686316, 2.98007472, 0.49385753]
+        self._ref_parameter_value_estimates_multi_reversed = [0.49940864, 1.11431227, 2.21686315, 2.972407]
         self._ref_y_model_value_estimates = self.xy_model_0(self._ref_x, *self._ref_parameter_value_estimates)
         self._ref_y_model_value_estimates_multi = np.append(
             self.xy_model_0(self._ref_x, *self._ref_parameter_value_estimates_multi[0:3]),
@@ -127,7 +133,8 @@ class TestFittersXYMulti(unittest.TestCase):
             _conflicting_defaults_fit = XYMultiFit(
                 xy_data=[self._ref_xy_data_0, self._ref_xy_data_1],
                 model_function=[self.xy_model_0, self.xy_model_1_conflicting_defaults],
-                cost_function=self.simple_chi2
+                cost_function=self.simple_chi2,
+                minimizer=DEFAULT_TEST_MINIMIZER
             )
 
     def test_before_fit_compare_parameter_values(self):
@@ -308,8 +315,9 @@ class TestFittersXYMulti(unittest.TestCase):
 
     def test_model_nodefaults(self):
         xy_fit = XYMultiFit(xy_data=self._ref_xy_data_0,
-                             model_function=self.xy_model_nodefaults,
-                             cost_function=self.simple_chi2)
+                            model_function=self.xy_model_nodefaults,
+                            cost_function=self.simple_chi2,
+                            minimizer=DEFAULT_TEST_MINIMIZER)
         self.assertTrue(
             np.allclose(
                 xy_fit.parameter_values,
@@ -320,8 +328,9 @@ class TestFittersXYMulti(unittest.TestCase):
 
     def test_model_partialdefaults(self):
         xy_fit = XYMultiFit(xy_data=self._ref_xy_data_0,
-                             model_function=self.xy_model_partialdefaults,
-                             cost_function=self.simple_chi2)
+                            model_function=self.xy_model_partialdefaults,
+                            cost_function=self.simple_chi2,
+                            minimizer=DEFAULT_TEST_MINIMIZER)
         self.assertTrue(
             np.allclose(
                 xy_fit.parameter_values,
@@ -332,31 +341,31 @@ class TestFittersXYMulti(unittest.TestCase):
 
     def test_raise_reserved_parameter_names_in_model(self):
         with self.assertRaises(XYMultiFitException):
-            xy_fit_reserved_names = XYMultiFit(
-                            xy_data=self._ref_xy_data_0,
-                            model_function=self.xy_model_reserved_names,
-                            cost_function=self.simple_chi2)
+            xy_fit_reserved_names = XYMultiFit(xy_data=self._ref_xy_data_0,
+                                               model_function=self.xy_model_reserved_names,
+                                               cost_function=self.simple_chi2,
+                                               minimizer=DEFAULT_TEST_MINIMIZER)
 
     def test_raise_varargs_in_model(self):
         with self.assertRaises(XYModelFunctionException):
-            xy_fit_reserved_names = XYMultiFit(
-                            xy_data=self._ref_xy_data_0,
-                            model_function=self.xy_model_varargs,
-                            cost_function=self.simple_chi2)
+            xy_fit_reserved_names = XYMultiFit(xy_data=self._ref_xy_data_0,
+                                               model_function=self.xy_model_varargs,
+                                               cost_function=self.simple_chi2,
+                                               minimizer=DEFAULT_TEST_MINIMIZER)
 
     def test_raise_varkwargs_in_model(self):
         with self.assertRaises(XYModelFunctionException):
-            xy_fit_reserved_names = XYMultiFit(
-                            xy_data=self._ref_xy_data_0,
-                            model_function=self.xy_model_varkwargs,
-                            cost_function=self.simple_chi2)
+            xy_fit_reserved_names = XYMultiFit(xy_data=self._ref_xy_data_0,
+                                               model_function=self.xy_model_varkwargs,
+                                               cost_function=self.simple_chi2,
+                                               minimizer=DEFAULT_TEST_MINIMIZER)
 
     def test_raise_varargs_and_varkwargs_in_model(self):
         with self.assertRaises(XYModelFunctionException):
-            xy_fit_reserved_names = XYMultiFit(
-                            xy_data=self._ref_xy_data_0,
-                            model_function=self.xy_model_varargs_and_varkwargs,
-                            cost_function=self.simple_chi2)
+            xy_fit_reserved_names = XYMultiFit(xy_data=self._ref_xy_data_0,
+                                               model_function=self.xy_model_varargs_and_varkwargs,
+                                               cost_function=self.simple_chi2,
+                                               minimizer=DEFAULT_TEST_MINIMIZER)
 
 class TestFittersXYMultiChi2WithError(unittest.TestCase):
 
@@ -413,11 +422,13 @@ class TestFittersXYMultiChi2WithError(unittest.TestCase):
 
         self.xy_fit = XYMultiFit(xy_data=self._ref_xy_data_0,
                                  model_function=self.xy_model_0,
-                                 cost_function=self.chi2_with_error)
+                                 cost_function=self.chi2_with_error,
+                                 minimizer=DEFAULT_TEST_MINIMIZER)
         
         self.xy_multi_fit = XYMultiFit(xy_data=[self._ref_xy_data_0, self._ref_xy_data_1],
                                        model_function=[self.xy_model_0, self.xy_model_1],
-                                       cost_function=self.chi2_with_error)
+                                       cost_function=self.chi2_with_error,
+                                       minimizer=DEFAULT_TEST_MINIMIZER)
 
         self.xy_fit.add_simple_error('y', self._ref_y_data_error_0,
                                      name="MyYDataError", correlation=0, relative=False, reference='data')
@@ -435,7 +446,7 @@ class TestFittersXYMultiChi2WithError(unittest.TestCase):
 
         self._ref_y_total_error = np.sqrt(self._ref_y_data_error_0 ** 2 + self._ref_y_model_error_0 ** 2)
 
-        self._ref_parameter_value_estimates = [1.1351433845831516, 2.137441531781195, 2.3405503488535118]
+        self._ref_parameter_value_estimates = [1.1351433, 2.13736919, 2.33346549]
         self._ref_model_value_estimates = self.xy_model_0(self._ref_x, *self._ref_parameter_value_estimates)
 
     def test_get_matching_error_all_empty_dict(self):
@@ -507,7 +518,8 @@ class TestFittersXYMultiChi2WithError(unittest.TestCase):
         self.xy_fit_chi2_with_cov_mat = XYMultiFit(
                                   xy_data=self._ref_xy_data_0,
                                   model_function=self.xy_model_0,
-                                  cost_function=self.chi2_with_cov_mat)
+                                  cost_function=self.chi2_with_cov_mat,
+                                  minimizer=DEFAULT_TEST_MINIMIZER)
         self.xy_fit_chi2_with_cov_mat.add_simple_error('y', self._ref_y_data_error_0, correlation=0, relative=False, reference='data')
         self.xy_fit_chi2_with_cov_mat.do_fit()
 


### PR DESCRIPTION
Change unit tests to always use the scipy minimizer. This no longer causes the tests to fail on system without iminuit.