### PR TITLE
Add function to manually set bin heights

### DIFF
--- a/kafe2/fit/representation/container/yaml_drepr.py
+++ b/kafe2/fit/representation/container/yaml_drepr.py
@@ -7,7 +7,7 @@ from ....fit import HistContainer, IndexedContainer, XYContainer, UnbinnedContai
 from .. import _AVAILABLE_REPRESENTATIONS
 from ._base import DataContainerDReprBase
 from .._base import DReprError
-from .._yaml_base import YamlWriterMixin, YamlReaderMixin, YamlReaderException
+from .._yaml_base import YamlWriterMixin, YamlReaderMixin, YamlReaderException, YamlWriterException
 
 __all__ = ["DataContainerYamlReader", "DataContainerYamlWriter"]
 
@@ -167,6 +167,9 @@ class DataContainerYamlWriter(YamlWriterMixin, DataContainerDReprBase):
 
         # -- write representation for container types
         if _class is HistContainer:
+            # TODO: Add manual bin height support
+            if container._manual_heights:
+                raise YamlWriterException("Manual set bins are not yet supported with kafe2go.")
             _yaml_doc['bin_edges'] = container.bin_edges.tolist()
             _yaml_doc['raw_data'] = list(map(float, container.raw_data))  # float64 -> float
         elif _class is IndexedContainer or _class is UnbinnedContainer:

--- a/kafe2/test/fit/test_containers_histogram.py
+++ b/kafe2/test/fit/test_containers_histogram.py
@@ -20,6 +20,7 @@ class TestDatastoreHistogram(unittest.TestCase):
         self._ref_bin_edges_manual_equalspacing = np.linspace(0, 10, self._ref_n_bins_manual + 1)
                                                     # [0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 , 10]
         self._ref_data_manual_equalspacing = np.array([  0,  0,  1,  1,  0,  1,  0,  0,  1,  0])
+        self._ref_bin_heights_manual =       np.array([  5,  4, 10,  3,  0, 15,  7,  4, 20,  1])
 
         self._ref_bin_edges_manual_variablespacing =   [0 , 2 , 3 , 3.1 , 3.2 , 3.3 , 3.4 , 7 , 8.5 , 9 , 10]
         self._ref_data_manual_variablespacing = np.array([  0,  1,  0,    0,    0,    1,    1,  0,    1,  0])
@@ -88,6 +89,11 @@ class TestDatastoreHistogram(unittest.TestCase):
             np.allclose(self.hist_cont_binedges_auto.data, self._ref_data_manual_variablespacing)
         )
 
+    def test_manual_bin_height(self):
+        self.hist_cont_binedges_manual_equal.set_bins(self._ref_bin_heights_manual)
+        self.assertTrue(np.alltrue(self.hist_cont_binedges_manual_equal.data == self._ref_bin_heights_manual))
+        self.assertTrue(self.hist_cont_binedges_manual_equal._manual_heights)
+
     def test_construct_bin_edges_variablespacing_withedges(self):
         _hc = HistContainer(self._ref_n_bins_manual, self._ref_n_bin_range, bin_edges=self._probe_bin_edges_variablespacing_withedges)
 
@@ -131,6 +137,11 @@ class TestDatastoreHistogram(unittest.TestCase):
     def test_raise_get_inexistent_error(self):
         with self.assertRaises(DataContainerException):
             self.hist_cont_binedges_auto.get_error("MyInexistentError")
+
+    def test_raise_manual_bin_heights_rebin(self):
+        self.hist_cont_binedges_manual_equal.set_bins(self._ref_bin_heights_manual)
+        with self.assertRaises(DataContainerException):
+            self.hist_cont_binedges_manual_equal.rebin(self._ref_bin_edges_manual_variablespacing)
 
 
 class TestDatastoreHistParametricModel(unittest.TestCase):


### PR DESCRIPTION
This is a requested feature for a bachelor thesis.
The new function lets the user set the heights of the bins, e.g. if the data is only given as a histogram.
This comes with a small performance decrease when getting the number of entries, as now a sum has to calculated instead of len().