### PR TITLE
Support unbinned fits in the yaml representer

### DIFF
--- a/kafe2/core/fitters/nexus_fitter.py
+++ b/kafe2/core/fitters/nexus_fitter.py
@@ -35,6 +35,9 @@ class NexusFitter(object):
             **minimizer_kwargs
         )
 
+        self._fixed_pars = dict()
+        self._limited_pars = dict()
+
         # flags
         self.__minimizing = False  # minimization ongoing?
         self.__state_is_from_minimizer = False
@@ -146,6 +149,14 @@ class NexusFitter(object):
     def state_is_from_minimizer(self):
         return self.__state_is_from_minimizer
 
+    @property
+    def fixed_parameters(self):
+        return self._fixed_pars.copy()
+
+    @property
+    def limited_parameters(self):
+        return self._limited_pars.copy()
+
     # -- public methods
 
     def do_fit(self):
@@ -156,15 +167,20 @@ class NexusFitter(object):
             self.set_fit_parameter_values(**{par_name: par_value})
 
         self._minimizer.fix(par_name)
+        _fixed_par_dict = self.get_fit_parameter_values([par_name])
+        self._fixed_pars.update(_fixed_par_dict)
 
     def release_parameter(self, par_name):
         self._minimizer.release(par_name)
+        self._fixed_pars.pop(par_name, None)
 
     def limit_parameter(self, par_name, par_limits):
         self._minimizer.limit(par_name, par_limits)
+        self._limited_pars.update({par_name: par_limits})
 
     def unlimit_parameter(self, par_name):
         self._minimizer.unlimit(par_name)
+        self._limited_pars.pop(par_name, None)
 
     def contour(self, parameter_name_1, parameter_name_2, sigma=1.0, **kwargs):
         if not self.__state_is_from_minimizer:

--- a/kafe2/fit/representation/container/_base.py
+++ b/kafe2/fit/representation/container/_base.py
@@ -5,6 +5,7 @@ from .._base import GenericDReprBase
 # import data container classes
 from ...histogram import HistContainer
 from ...indexed import IndexedContainer
+from ...unbinned import UnbinnedContainer
 from ...xy import XYContainer
 
 __all__ = ["DataContainerDReprBase"]
@@ -17,11 +18,13 @@ class DataContainerDReprBase(GenericDReprBase):
     _CLASS_TO_OBJECT_TYPE_NAME = {
         HistContainer: 'histogram',
         IndexedContainer: 'indexed',
+        UnbinnedContainer: 'unbinned',
         XYContainer: 'xy'
     }
     _OBJECT_TYPE_NAME_TO_CLASS = {
         'histogram': HistContainer,
         'indexed': IndexedContainer,
+        'unbinned': UnbinnedContainer,
         'xy': XYContainer
     }
 

--- a/kafe2/fit/representation/container/yaml_drepr.py
+++ b/kafe2/fit/representation/container/yaml_drepr.py
@@ -3,7 +3,7 @@ import re
 import yaml
 
 from ....core.error import SimpleGaussianError, MatrixGaussianError
-from ....fit import HistContainer, IndexedContainer, XYContainer
+from ....fit import HistContainer, IndexedContainer, XYContainer, UnbinnedContainer
 from .. import _AVAILABLE_REPRESENTATIONS
 from ._base import DataContainerDReprBase
 from .._base import DReprError
@@ -169,7 +169,7 @@ class DataContainerYamlWriter(YamlWriterMixin, DataContainerDReprBase):
         if _class is HistContainer:
             _yaml_doc['bin_edges'] = container.bin_edges.tolist()
             _yaml_doc['raw_data'] = list(map(float, container.raw_data))  # float64 -> float
-        elif _class is IndexedContainer:
+        elif _class is IndexedContainer or _class is UnbinnedContainer:
             _yaml_doc['data'] = container.data.tolist()
         elif _class is XYContainer:
             _yaml_doc['x_data'] = container.x.tolist()
@@ -215,7 +215,7 @@ class DataContainerYamlReader(YamlReaderMixin, DataContainerDReprBase):
     def _get_required_keywords(cls, yaml_doc, container_class):
         if container_class is HistContainer:
             return ['raw_data']
-        if container_class is IndexedContainer:
+        if container_class is IndexedContainer or container_class is UnbinnedContainer:
             return ['data']
         if container_class is XYContainer:
             return ['x_data', 'y_data']
@@ -246,6 +246,9 @@ class DataContainerYamlReader(YamlReaderMixin, DataContainerDReprBase):
         elif _class is IndexedContainer:
             _data = yaml_doc.pop('data')
             _container_obj = IndexedContainer(_data)
+        elif _class is UnbinnedContainer:
+            _data = yaml_doc.pop('data')
+            _container_obj = UnbinnedContainer(_data)
         elif _class is XYContainer:
             _x_data = yaml_doc.pop('x_data')
             _y_data = yaml_doc.pop('y_data')

--- a/kafe2/fit/representation/fit/_base.py
+++ b/kafe2/fit/representation/fit/_base.py
@@ -6,6 +6,7 @@ from .._base import GenericDReprBase
 from ...indexed import IndexedFit
 from ...xy import XYFit
 from ...histogram import HistFit
+from ...unbinned import UnbinnedFit
 
 __all__ = ["FitDReprBase"]
 
@@ -17,11 +18,13 @@ class FitDReprBase(GenericDReprBase):
     _CLASS_TO_OBJECT_TYPE_NAME = {
         HistFit: 'histogram',
         IndexedFit: 'indexed',
+        UnbinnedFit: 'unbinned',
         XYFit: 'xy'
     }
     _OBJECT_TYPE_NAME_TO_CLASS = {
         'histogram': HistFit,
         'indexed': IndexedFit,
+        'unbinned': UnbinnedFit,
         'xy': XYFit
     }
 

--- a/kafe2/fit/representation/fit/yaml_drepr.py
+++ b/kafe2/fit/representation/fit/yaml_drepr.py
@@ -4,7 +4,7 @@ from .._base import DReprError
 from .._yaml_base import YamlWriterMixin, YamlReaderMixin, YamlReaderException
 from ._base import FitDReprBase
 from .. import _AVAILABLE_REPRESENTATIONS
-from ....fit import IndexedFit, HistFit, XYFit
+from ....fit import IndexedFit, HistFit, UnbinnedFit, XYFit
 from ..container.yaml_drepr import DataContainerYamlReader, DataContainerYamlWriter
 from ..model.yaml_drepr import ParametricModelYamlReader, ParametricModelYamlWriter
 from ..constraint.yaml_drepr import ConstraintYamlReader, ConstraintYamlWriter
@@ -119,9 +119,9 @@ class FitYamlReader(YamlReaderMixin, FitDReprBase):
     
     @classmethod
     def _get_subspace_override_dict(cls, fit_class):
-        _override_dict = {'model_parameters':'parametric_model',
-                          'arg_formatters':'parametric_model',
-                          'model_function_formatter':'parametric_model'}
+        _override_dict = {'model_parameters': 'parametric_model',
+                          'arg_formatters': 'parametric_model',
+                          'model_function_formatter': 'parametric_model'}
 
         if fit_class is HistFit:
             _override_dict['n_bins'] = ['dataset', 'parametric_model']
@@ -132,8 +132,6 @@ class FitYamlReader(YamlReaderMixin, FitDReprBase):
             _override_dict['model_density_function'] = 'parametric_model'
             _override_dict['model_density_function_name'] = 'parametric_model'
             _override_dict['latex_model_density_function_name'] = 'parametric_model'
-            _override_dict['x_name'] = 'parametric_model'
-            _override_dict['latex_x_name'] = 'parametric_model'
             _override_dict['expression_string'] = 'parametric_model'
             _override_dict['latex_expression_string'] = 'parametric_model'
         elif fit_class is IndexedFit:
@@ -146,6 +144,13 @@ class FitYamlReader(YamlReaderMixin, FitDReprBase):
             _override_dict['latex_index_name'] = 'parametric_model'
             _override_dict['expression_string'] = 'parametric_model'
             _override_dict['latex_expression_string'] = 'parametric_model'
+        elif fit_class is UnbinnedFit:
+            _override_dict['data'] = ['dataset', 'parametric_model']
+            _override_dict['model_function'] = 'parametric_model'
+            _override_dict['model_function_name'] = 'parametric_model'
+            _override_dict['latex_model_function_name'] = 'parametric_model'
+            _override_dict['expression_string'] = 'parametric_model'
+            _override_dict['latex_expression_string'] = 'parametric_model'
         elif fit_class is XYFit:
             _override_dict['x_data'] = ['dataset', 'parametric_model']
             _override_dict['y_data'] = 'dataset'
@@ -154,8 +159,6 @@ class FitYamlReader(YamlReaderMixin, FitDReprBase):
             _override_dict['model_function'] = 'parametric_model'
             _override_dict['model_function_name'] = 'parametric_model'
             _override_dict['latex_model_function_name'] = 'parametric_model'
-            _override_dict['x_name'] = 'parametric_model'
-            _override_dict['latex_x_name'] = 'parametric_model'
             _override_dict['expression_string'] = 'parametric_model'
             _override_dict['latex_expression_string'] = 'parametric_model'
         else:
@@ -196,6 +199,13 @@ class FitYamlReader(YamlReaderMixin, FitDReprBase):
             _fit_object = IndexedFit(
                 data=_data,
                 model_function=_read_model_function,
+                minimizer=_minimizer,
+                minimizer_kwargs=_minimizer_kwargs
+            )
+        elif _class is UnbinnedFit:
+            _fit_object = UnbinnedFit(
+                data=_data,
+                model_density_function=_read_model_function,
                 minimizer=_minimizer,
                 minimizer_kwargs=_minimizer_kwargs
             )

--- a/kafe2/fit/representation/format/_base.py
+++ b/kafe2/fit/representation/format/_base.py
@@ -13,7 +13,8 @@ __all__ = ["ModelFunctionFormatterDReprBase", "ModelParameterFormatterDReprBase"
 class ModelFunctionFormatterDReprBase(GenericDReprBase):
     BASE_OBJECT_TYPE_NAME = 'model_function_formatter'
 
-    #TODO type aliases
+    # This dict is currently not used. Because there are only two different formatters adn most fits use the base format
+    # Case separation is currently only handled in the yaml_drepr.py
     _CLASS_TO_OBJECT_TYPE_NAME = {
         ModelFunctionFormatter: 'base',
         IndexedModelFunctionFormatter: 'indexed'

--- a/kafe2/fit/representation/format/yaml_drepr.py
+++ b/kafe2/fit/representation/format/yaml_drepr.py
@@ -2,8 +2,8 @@ from .._base import DReprError
 from .._yaml_base import YamlWriterMixin, YamlReaderMixin
 from ._base import ModelFunctionFormatterDReprBase, ModelParameterFormatterDReprBase
 from .. import _AVAILABLE_REPRESENTATIONS
-from ....fit._base import ParameterFormatter, ModelFunctionFormatter
-from ....fit import IndexedModelFunctionFormatter
+from ..._base import ParameterFormatter, ModelFunctionFormatter
+from ...indexed import IndexedModelFunctionFormatter
 from .._yaml_base import YamlReaderException, YamlWriterException
 
 __all__ = ['ModelFunctionFormatterYamlWriter', 'ModelFunctionFormatterYamlReader', 

--- a/kafe2/fit/representation/model/_base.py
+++ b/kafe2/fit/representation/model/_base.py
@@ -6,6 +6,7 @@ from .._base import GenericDReprBase
 from ..._base import ModelFunctionBase
 from ...histogram import HistModelFunction, HistParametricModel
 from ...indexed import IndexedModelFunction, IndexedParametricModel
+from ...unbinned import UnbinnedParametricModel
 from ...xy import XYParametricModel
 
 __all__ = ["ModelFunctionDReprBase", "ParametricModelDReprBase"]
@@ -23,6 +24,7 @@ class ModelFunctionDReprBase(GenericDReprBase):
     _OBJECT_TYPE_NAME_TO_CLASS = {
         'histogram': HistModelFunction,
         'indexed': IndexedModelFunction,
+        'unbinned': ModelFunctionBase,
         'xy': ModelFunctionBase,  # type from fit is passed to model function, needs to be resolved
         'base': ModelFunctionBase
     }
@@ -39,11 +41,13 @@ class ParametricModelDReprBase(GenericDReprBase):
     _CLASS_TO_OBJECT_TYPE_NAME = {
         HistParametricModel: 'histogram',
         IndexedParametricModel: 'indexed',
+        UnbinnedParametricModel: 'unbinned',
         XYParametricModel: 'xy'
     }
     _OBJECT_TYPE_NAME_TO_CLASS = {
         'histogram': HistParametricModel,
         'indexed': IndexedParametricModel,
+        'unbinned': UnbinnedParametricModel,
         'xy': XYParametricModel
     }
 

--- a/kafe2/tools.py
+++ b/kafe2/tools.py
@@ -136,16 +136,21 @@ def get_compact_representation(parameter_names, parameter_values, parameter_erro
         for _i, (_par_name, _par_val, _par_err, _cor_mat_row_str) in enumerate(
                 zip(parameter_names, parameter_values, parameter_errors, _cor_mat_row_strs)):
             _row = [_par_name]
-            _sig_fig_err = max(2, -int(np.log10(np.abs(_par_err))) + 1)
-            _sig_fig_val = max(_sig_fig_err, -int(np.log10(np.abs(_par_val))) + 2)
-            _row.append(round(_par_val, _sig_fig_val))
-            _row.append(round(_par_err, _sig_fig_err))
+            if np.isnan(_par_err) or _par_err == 0.0:  # check if parameter is fixed
+                _row.append(_par_val)
+                _row.append('fixed')
+            else:  # parameter is not fixed, round and add errors
+                _sig_fig_err = max(2, -int(np.log10(np.abs(_par_err))) + 1)
+                _sig_fig_val = max(_sig_fig_err, -int(np.log10(np.abs(_par_val))) + 2)
+                _row.append(round(_par_val, _sig_fig_val))
+                _row.append(round(_par_err, _sig_fig_err))
             if asymmetric_parameter_errors is not None:
-                _err_down, _err_up = asymmetric_parameter_errors[_i]
-                _sig_fig_err_down = max(2, -int(np.log10(np.abs(_err_down))) + 1)
-                _row.append(round(_err_down, _sig_fig_err_down))
-                _sig_fig_err_up = max(2, -int(np.log10(np.abs(_err_up))) + 1)
-                _row.append(round(_err_up, _sig_fig_err_up))
+                for _err in asymmetric_parameter_errors[_i]:  # iterate over up and down error
+                    if np.isnan(_err):  # parameter is fixed, no error available
+                        _row.append('N/A')
+                    else:
+                        _sig_err = max(2, -int(np.log10(np.abs(_err))) + 1)
+                        _row.append(round(_err, _sig_err))
             _row.append(_cor_mat_row_str)
             _data.append(_row)
 


### PR DESCRIPTION
This PR adds support for unbinned fits in the yaml representer. Closes #58 

* [x] implement repr for unbinned fits
* [x] support fixed parameters in kafe2go fixes #104
* [x] add unittests (more tests needed for limited and fixed pars)