### PR TITLE
Profile minimum misalignment fix

### DIFF
--- a/kafe2/core/minimizers/minimizer_base.py
+++ b/kafe2/core/minimizers/minimizer_base.py
@@ -24,16 +24,36 @@ class MinimizerBase(object):
         self._par_cov_mat = None
 
     def _save_state(self):
-        self._save_state_dict['asymmetric_parameter_error'] = np.array(self._par_asymm_err)
-        self._save_state_dict['hessian'] = np.array(self._hessian)
-        self._save_state_dict['hessian_inv'] = np.array(self._hessian_inv)
-        self._save_state_dict['par_cov_mat'] = np.array(self._par_cov_mat)
+        if self._par_asymm_err is None:
+            self._save_state_dict['asymmetric_parameter_error'] = self._par_asymm_err
+        else:
+            self._save_state_dict['asymmetric_parameter_error'] = np.array(self._par_asymm_err)
+        if self._hessian is None:
+            self._save_state_dict['hessian'] = self._hessian
+        else:
+            self._save_state_dict['hessian'] = np.array(self._hessian)
+        if self._hessian_inv is None:
+            self._save_state_dict['hessian_inv'] = self._hessian_inv
+        else:
+            self._save_state_dict['hessian_inv'] = np.array(self._hessian_inv)
+        if self._par_cov_mat is None:
+            self._save_state_dict['par_cov_mat'] = self._par_cov_mat
+        else:
+            self._save_state_dict['par_cov_mat'] = np.array(self._par_cov_mat)
 
     def _load_state(self):
-        self._par_asymm_err = np.array(self._save_state_dict['asymmetric_parameter_error'])
-        self._hessian = np.array(self._save_state_dict['hessian'])
-        self._hessian_inv = np.array(self._save_state_dict['hessian_inv'])
-        self._par_cov_mat = np.array(self._save_state_dict['par_cov_mat'])
+        self._par_asymm_err = self._save_state_dict['asymmetric_parameter_error']
+        if self._par_asymm_err is not None:
+            self._par_asymm_err = np.array(self._par_asymm_err)
+        self._hessian = self._save_state_dict['hessian']
+        if self._hessian is not None:
+            self._hessian = np.array(self._hessian)
+        self._hessian_inv = self._save_state_dict['hessian_inv']
+        if self._hessian_inv is not None:
+            self._hessian_inv = np.array(self._hessian_inv)
+        self._par_cov_mat = self._save_state_dict['par_cov_mat']
+        if self._par_cov_mat is not None:
+            self._par_cov_mat = np.array(self._par_cov_mat)
         # Write back parameter values to nexus parameter nodes:
         self._func_wrapper_unpack_args(self.parameter_values)
 

--- a/kafe2/fit/xy/container.py
+++ b/kafe2/fit/xy/container.py
@@ -55,7 +55,7 @@ class XYContainer(IndexedContainer):
         return _axis_id
 
     def _get_data_for_axis(self, axis_id):
-        return self._data[axis_id]
+        return np.array(self._data[axis_id])
 
     def _calculate_total_error(self):
         _sz = self.size


### PR DESCRIPTION
Fixes https://github.com/dsavoiu/kafe2/issues/90 .
I fixed several bugs while investigating the above issue:

- Calling `cov_mat` or `cor_mat` changed the state of the iminuit minimizer.
- Calculating asymmetric parameter errors changed the state of the iminuit minimizer.
- `_save_state` and `_load_state` didn't work as intended.
- SciPy minimizer sometimes getting stuck on local minima when profiling.
- XYContainer not copying the data it returns, lead to the rounding of values when printing being applied to the actual data.

I tested the fixes I made on the Breit-Wigner example provided by @GuenterQuast as well as the examples `non_linear_fit.py` and `x_errors.py` found in `004_non_linear_fit`.

The following table shows the cost function values received when fitting with iminuit or scipy on the current master branch or on the branch of this PR.
An *italic* cost function value indicates that the plot of the profiles and/or contours had misaligned minima between the parabolic minimum and the minimum of the profile.

| Test | iminuit, master | iminuit, PR | SciPy, master | Scipy, PR |
| --- | --- | --- | --- | --- |
| BreitWigner    | *2.094* | 0.6287 | *0.6287* | 0.6287 |
| non_linear_fit |  0.2824 | 0.2822 |  0.2824  | 0.2822 |
| x_errors       |  0.4309 | 0.4306 |  0.4309  | 0.4306 |

As indicated by the table, the fixes I added slightly changed the results of most fits.
For a high-precision fit the change is very large.
@GuenterQuast, please confirm if the results produced by this PR are reasonable.