### PR TITLE
Fix for inconsistent errors between MultiFit and single fits

### DIFF
--- a/kafe2/fit/_base/container.py
+++ b/kafe2/fit/_base/container.py
@@ -63,6 +63,14 @@ class DataContainerBase(FileIOMixin, object):
             _name = random_alphanumeric(size=8)
 
         additional_error_dict_keys.setdefault('enabled', True)  # enable error source, unless explicitly disabled
+
+        axis = additional_error_dict_keys.get("axis", None)
+        if axis is not None:
+            if axis == "x":
+                additional_error_dict_keys["axis"] = 0
+            elif axis == "y":
+                additional_error_dict_keys["axis"] = 1
+
         _new_err_dict = dict(err=error_object, **additional_error_dict_keys)
         self._error_dicts[_name] = _new_err_dict
         self._clear_total_error_cache()


### PR DESCRIPTION
Fixes https://github.com/dsavoiu/kafe2/issues/103.

When I investigated the issue I noticed that there is a general problem with the current implementation of MultiFit: the errors calculated in the MultiFit are inconsistent with the errors calculated in the single fits.
Because of this the fit results (calculated in MultiFit) differ from the plots and reports (generated from single fits).
I decided to fix the issue by changing how errors are stored in MultiFit: shared errors are now added to both the single fits and MultiFit.
To avoid applying errors twice MultiFit now no longer adds shared errors to the main diagonal blocks of the combined covariance matrix.