### PR TITLE
Fix for propagation of error changes

### DIFF
--- a/kafe2/core/fitters/nexus_fitter.py
+++ b/kafe2/core/fitters/nexus_fitter.py
@@ -243,3 +243,6 @@ class NexusFitter(object):
 
         # set flags
         self.__state_is_from_minimizer = False
+
+    def reset_minimizer(self):
+        self._minimizer.reset()

--- a/kafe2/core/minimizers/iminuit_minimizer.py
+++ b/kafe2/core/minimizers/iminuit_minimizer.py
@@ -28,16 +28,12 @@ class MinimizerIMinuit(MinimizerBase):
             self._minimizer_param_dict["fix_" + _pn] = False
             self._minimizer_param_dict["limit_" + _pn] = None
 
-        self._reset()  # sets self.__iminuit and caches to None
+        self.reset()  # sets self.__iminuit and caches to None
         self.errordef = 1.0
         self.tolerance = 1e-6
         super(MinimizerIMinuit, self).__init__(function_to_minimize=function_to_minimize)
 
     # -- private methods
-
-    def _reset(self):
-        self.__iminuit = None
-        self._invalidate_cache()
 
     def _invalidate_cache(self):
         self._par_val = None
@@ -69,7 +65,7 @@ class MinimizerIMinuit(MinimizerBase):
         super(MinimizerIMinuit, self)._save_state()
 
     def _load_state(self):
-        self._reset()
+        self.reset()
         self._par_val = self._save_state_dict["par_val"]
         if self._par_val is not None:
             self._par_val = np.array(self._par_val)
@@ -153,7 +149,7 @@ class MinimizerIMinuit(MinimizerBase):
     def errordef(self, err_def):
         assert err_def > 0
         self._err_def = err_def
-        self._reset()
+        self.reset()
 
     @property
     def tolerance(self):
@@ -163,7 +159,7 @@ class MinimizerIMinuit(MinimizerBase):
     def tolerance(self, tolerance):
         assert tolerance > 0
         self._tol = tolerance
-        self._reset()
+        self.reset()
 
     @property
     def hessian(self):
@@ -279,8 +275,11 @@ class MinimizerIMinuit(MinimizerBase):
         _fmin = self._get_fmin_struct()
         return _fmin.has_accurate_covar
 
-
     # -- public methods
+
+    def reset(self):
+        self.__iminuit = None
+        self._invalidate_cache()
 
     def contour(self, parameter_name_1, parameter_name_2, sigma=1.0, **minimizer_contour_kwargs):
         if self.__iminuit is None:
@@ -307,7 +306,7 @@ class MinimizerIMinuit(MinimizerBase):
         if parameter_name not in self._minimizer_param_dict:
             raise MinimizerIMinuitException("No parameter named '%s'!" % (parameter_name,))
         self._minimizer_param_dict[parameter_name] = parameter_value
-        self._reset()
+        self.reset()
 
     def set_several(self, parameter_names, parameter_values):
         for _pn, _pv in zip(parameter_names,parameter_values):
@@ -315,7 +314,7 @@ class MinimizerIMinuit(MinimizerBase):
 
     def fix(self, parameter_name):
         self._minimizer_param_dict["fix_" + parameter_name] = True
-        self._reset()
+        self.reset()
 
     def is_fixed(self, parameter_name):
         return self._minimizer_param_dict["fix_%s" % parameter_name]
@@ -326,7 +325,7 @@ class MinimizerIMinuit(MinimizerBase):
 
     def release(self, parameter_name):
         self._minimizer_param_dict["fix_" + parameter_name] = False
-        self._reset()
+        self.reset()
 
     def release_several(self, parameter_names):
         for _pn in parameter_names:
@@ -335,11 +334,11 @@ class MinimizerIMinuit(MinimizerBase):
     def limit(self, parameter_name, parameter_bounds):
         assert len(parameter_bounds) == 2
         self._minimizer_param_dict["limit_" + parameter_name] = (parameter_bounds[0], parameter_bounds[1])
-        self._reset()
+        self.reset()
 
     def unlimit(self, parameter_name):
         self._minimizer_param_dict["limit_" + parameter_name] = None
-        self._reset()
+        self.reset()
 
     def minimize(self, max_calls=6000):
         self._get_iminuit().migrad(ncall=max_calls)

--- a/kafe2/core/minimizers/minimizer_base.py
+++ b/kafe2/core/minimizers/minimizer_base.py
@@ -13,9 +13,6 @@ class MinimizerBase(object):
         self._save_state_dict = dict()
         self._printed_inf_cost_warning = False
 
-    def _reset(self):
-        self._invalidate_cache()
-
     def _invalidate_cache(self):
         self._fval = None
         self._par_asymm_err = None
@@ -188,6 +185,10 @@ class MinimizerBase(object):
         if self._par_cor_mat is None:
             self._par_cor_mat = CovMat(self.cov_mat).cor_mat
         return self._par_cor_mat
+
+    def reset(self):
+        """Clears caches and resets the internal state of used backends."""
+        self._invalidate_cache()
 
     def set(self, parameter_name, parameter_value):
         raise NotImplementedError()

--- a/kafe2/fit/_base/container.py
+++ b/kafe2/fit/_base/container.py
@@ -31,6 +31,7 @@ class DataContainerBase(FileIOMixin, object):
         self._total_error = None
         self._label = None
         self._axis_labels = (None, None)
+        self._on_error_change_callback = None
         super(DataContainerBase, self).__init__()
 
     # -- private methods
@@ -73,7 +74,7 @@ class DataContainerBase(FileIOMixin, object):
 
         _new_err_dict = dict(err=error_object, **additional_error_dict_keys)
         self._error_dicts[_name] = _new_err_dict
-        self._clear_total_error_cache()
+        self._on_error_change()
         return _name
 
     def _get_error_by_name_raise(self, error_name):
@@ -82,6 +83,11 @@ class DataContainerBase(FileIOMixin, object):
         if _err_dict is None:
             raise DataContainerException("No error with name '{}'!".format(error_name))
         return _err_dict
+
+    def _on_error_change(self):
+        self._clear_total_error_cache()
+        if self._on_error_change_callback is not None:
+            self._on_error_change_callback()
 
     @property
     def label(self):
@@ -264,7 +270,7 @@ class DataContainerBase(FileIOMixin, object):
         """
         _err_dict = self._get_error_by_name_raise(error_name)
         _err_dict['enabled'] = False
-        self._clear_total_error_cache()
+        self._on_error_change()
 
     def enable_error(self, error_name):
         """
@@ -276,7 +282,7 @@ class DataContainerBase(FileIOMixin, object):
         """
         _err_dict = self._get_error_by_name_raise(error_name)
         _err_dict['enabled'] = True
-        self._clear_total_error_cache()
+        self._on_error_change()
 
     def get_matching_errors(self, matching_criteria=None, matching_type='equal'):
         """

--- a/kafe2/fit/_base/fit.py
+++ b/kafe2/fit/_base/fit.py
@@ -33,6 +33,7 @@ class FitBase(FileIOMixin, object):
     PLOT_ADAPTER_TYPE = None
     EXCEPTION_TYPE = FitException
     RESERVED_NODE_NAMES = None
+    _BASIC_ERROR_NAMES = {}
 
     def __init__(self):
         self._data_container = None
@@ -90,6 +91,9 @@ class FitBase(FileIOMixin, object):
             raise self.__class__.EXCEPTION_TYPE(
                 "The following names are reserved and cannot be used as model function arguments: %r"
                 % (_invalid_args,))
+
+    def _init_nexus(self):
+        pass
 
     def _initialize_fitter(self):
         self._fitter = NexusFitter(nexus=self._nexus,
@@ -212,6 +216,11 @@ class FitBase(FileIOMixin, object):
         if update_asymmetric_errors:
             for _fpf, _ape in zip(self._get_model_function_parameter_formatters(), self.asymmetric_parameter_errors):
                 _fpf.asymmetric_error = _ape
+
+    def _on_error_change(self):
+        self._fitter.reset_minimizer()
+        for _error_name in self._BASIC_ERROR_NAMES:
+            self._nexus.get(_error_name).mark_for_update()
 
     # -- public properties
 

--- a/kafe2/fit/histogram/fit.py
+++ b/kafe2/fit/histogram/fit.py
@@ -31,6 +31,7 @@ class HistFit(FitBase):
                           'data_error', 'model_error', 'total_error',
                           'data_cov_mat', 'model_cov_mat', 'total_cov_mat',
                           'data_cor_mat', 'model_cor_mat', 'total_cor_mat'}
+    _BASIC_ERROR_NAMES = {'data_error', 'model_error', 'data_cov_mat', 'model_cov_mat'}
 
     def __init__(self,
                  data,
@@ -230,6 +231,7 @@ class HistFit(FitBase):
                                    .format(type(new_data), self.CONTAINER_TYPE))
         else:
             raise HistFitException("Fitting a histogram requires a HistContainer!")
+        self._data_container._on_error_change_callback = self._on_error_change
 
         self._nexus.get('data').mark_for_update()
 
@@ -242,6 +244,7 @@ class HistFit(FitBase):
                                                        self._data_container.bin_edges,
                                                        model_density_func_antiderivative=
                                                        self._model_function.antiderivative)
+        self._param_model._on_error_change_callbacks = [self._on_error_change]
 
     # -- public properties
 

--- a/kafe2/fit/indexed/fit.py
+++ b/kafe2/fit/indexed/fit.py
@@ -35,6 +35,7 @@ class IndexedFit(FitBase):
                           'data_error', 'model_error', 'total_error',
                           'data_cov_mat', 'model_cov_mat', 'total_cov_mat',
                           'data_cor_mat', 'model_cor_mat', 'total_cor_mat'}
+    _BASIC_ERROR_NAMES = {'data_error', 'model_error', 'data_cov_mat', 'model_cov_mat'}
 
     def __init__(self,
                  data,
@@ -260,6 +261,7 @@ class IndexedFit(FitBase):
                                       % (type(new_data), self.CONTAINER_TYPE))
         else:
             self._data_container = self._new_data_container(new_data, dtype=float)
+        self._data_container._on_error_change_callback = self._on_error_change
 
         self._nexus.get('data').mark_for_update()
 
@@ -269,6 +271,7 @@ class IndexedFit(FitBase):
             self.parameter_values,
             shape_like=self.data
         )
+        self._param_model._on_error_change_callbacks = [self._on_error_change]
 
     # -- public properties
 

--- a/kafe2/fit/multi/fit.py
+++ b/kafe2/fit/multi/fit.py
@@ -378,8 +378,7 @@ class MultiFit(FitBase):
             else:
                 raise ValueError()
             _target._add_error_object(name=name, error_object=error_object, axis=axis)
-            _fit._init_nexus()
-        # self._init_nexus()  # Don't have to call self._init_nexus due to callback in single fits
+        self._on_error_change()
         return name
 
     def _set_new_data(self, new_data):

--- a/kafe2/fit/unbinned/fit.py
+++ b/kafe2/fit/unbinned/fit.py
@@ -157,6 +157,7 @@ class UnbinnedFit(FitBase):
                                        % (type(new_data), self.CONTAINER_TYPE))
         else:
             self._data_container = self._new_data_container(new_data, dtype=float)
+        self._data_container._on_error_change_callback = self._on_error_change
 
         self._nexus.get('x').mark_for_update()
         # TODO: make 'Alias' nodes pass on 'mark_for_update'
@@ -168,6 +169,7 @@ class UnbinnedFit(FitBase):
             model_density_function=self._model_function,
             model_parameters=self.parameter_values
         )
+        self._param_model._on_error_change_callbacks = [self._on_error_change]
 
     @FitBase.data.getter
     def data(self):


### PR DESCRIPTION
Fixes https://github.com/dsavoiu/kafe2/issues/91.

Currently changes to errors are not always being correctly propagated.
For example, disabling/enabling errors while using the iminuit minimizer after fitting once had no effect due to caches in the iminuit minimizer not being cleared.
The behavior when changing errors was also inconsistent in general: adding a simple error for XYFit resulted in a complete rebuild of the nexus, adding a matrix error for XYFit propagated the error change through the nexus, adding an error to any other fit or disabling/enabling an error neither rebuilt the nexus nor propagated the error change through the nexus.

This PR adds private methods _on_error_change to both containers and fits that make their behavior consistent.
The current implementation of FitBase._on_error_change is to *always* rebuild the nexus when any of the errors change.
This is likely overkill and it seems to also introduce side effects.
For example, when the nexus is rebuilt all parameter values are reset to their default value.
I think for the current functionality rebuilding the nexus can be replaced with propagating the error changes through the nexus and calling the _reset method of the minimizer.
However, the previous implementation of nuisance parameters relied on the nexus being rebuilt upon error change; a new implementation would need to be adapted in order to conserve consistency.
Feedback on the matter would be greatly appreciated!