### PR TITLE
Fix for MultiFits showing only global chi2/ndf

### DIFF
--- a/kafe2/fit/_base/plot.py
+++ b/kafe2/fit/_base/plot.py
@@ -707,13 +707,9 @@ class Plot(object):
 
         _cost_func = plot_adapter._fit._cost_function  # TODO: public interface
 
-        if self._multifit is None:
-            _ndf = _cost_func.ndf
-            _cost_function_value = plot_adapter._fit.cost_function_value
-        else:
-            _ndf = self._multifit.ndf
-            _cost_function_value = self._multifit.cost_function_value
-        return self.FIT_INFO_STRING_FORMAT.format(
+        _ndf = _cost_func.ndf
+        _cost_function_value = plot_adapter._fit.cost_function_value
+        _info_text = self.FIT_INFO_STRING_FORMAT.format(
             model_function=plot_adapter.get_formatted_model_function(
                 with_par_values=False,
                 n_significant_digits=2,
@@ -737,6 +733,17 @@ class Plot(object):
                 format_as_latex=format_as_latex
             ),
         )
+        if self._multifit is not None:
+            _multi_ndf = self._multifit.ndf
+            _multi_cost_function_value = self._multifit.cost_function_value
+            _info_text += "    $\\hookrightarrow$ global {}".format(
+                _cost_func._formatter.get_formatted(
+                    value=_multi_cost_function_value,
+                    n_degrees_of_freedom=_multi_ndf,
+                    with_value_per_ndf=True,
+                    format_as_latex=format_as_latex
+                ))
+        return _info_text
 
     def _render_legend(self, plot_results, axes_keys, fit_info=True, asymmetric_parameter_errors=False, **kwargs):
         """render the legend for axes `axes_keys`"""


### PR DESCRIPTION
Fixes https://github.com/dsavoiu/kafe2/issues/97.

Since there were no specific instructions regarding how global chi2/ndf should be displayed I decided on the arrangement myself.
@GuenterQuast please confirm whether it looks like you imagined it.
It should look something like this:

![multi_fit_1](https://user-images.githubusercontent.com/18492268/76333212-95e9f680-62f1-11ea-8d5f-dd8ae2124d5b.png)
![multi_fit_2](https://user-images.githubusercontent.com/18492268/76333222-9a161400-62f1-11ea-9338-2d435e0a11a3.png)
