### PR TITLE
Add ability to modify the plot range

### DIFF
--- a/kafe2/fit/_base/plot.py
+++ b/kafe2/fit/_base/plot.py
@@ -692,7 +692,7 @@ class Plot(object):
                         max(_xlim[1], _pdc.x_range[1])
                     )
 
-                if _pdc.y_range is not None:
+                if _pdc.y_range is not None and _axes_key != 'ratio':  # y_range of ratio can be adjusted by plot kwargs
                     _ylim = _axes_plot_dicts.setdefault(
                         'y_range', _pdc.y_range)
                     _axes_plot_dicts['y_range'] = (

--- a/kafe2/fit/histogram/plot.py
+++ b/kafe2/fit/histogram/plot.py
@@ -35,6 +35,7 @@ class HistPlotAdapter(PlotAdapterBase):
         """
         super(HistPlotAdapter, self).__init__(fit_object=hist_fit_object)
         self._n_plot_points_model_density = n_plot_points_model_density
+        self.x_range = self._fit.data_container.bin_range
 
     # -- private methods
 
@@ -103,16 +104,6 @@ class HistPlotAdapter(PlotAdapterBase):
         _mean_bin_size = float(_hist_cont.high - _hist_cont.low)/_hist_cont.size
         _factor = _hist_cont.n_entries * _mean_bin_size
         return _factor * self._fit.eval_model_function_density(x=self.model_density_x)
-
-    @property
-    def x_range(self):
-        """x plot range (the histogram bin range)"""
-        return self._fit.data_container.bin_range
-
-    @property
-    def y_range(self):
-        """y plot range: ``None`` for :py:obj:`IndexedPlotContainer`"""
-        return None  # no fixed range
 
     # public methods
 

--- a/kafe2/fit/histogram/plot.py
+++ b/kafe2/fit/histogram/plot.py
@@ -26,7 +26,7 @@ class HistPlotAdapter(PlotAdapterBase):
         ),
     )
 
-    def __init__(self, hist_fit_object, n_plot_points_model_density=100):
+    def __init__(self, hist_fit_object):
         """
         Construct an :py:obj:`HistPlotContainer` for a :py:obj:`~kafe2.fit.histogram.HistFit` object:
 
@@ -34,7 +34,7 @@ class HistPlotAdapter(PlotAdapterBase):
         :param n_plot_points_model_density: number of plot points to use for plotting the model density
         """
         super(HistPlotAdapter, self).__init__(fit_object=hist_fit_object)
-        self._n_plot_points_model_density = n_plot_points_model_density
+        self.n_plot_points = 100 if len(self.data_x) < 100 else len(self.data_x)
         self.x_range = self._fit.data_container.bin_range
 
     # -- private methods
@@ -95,7 +95,7 @@ class HistPlotAdapter(PlotAdapterBase):
     def model_density_x(self):
         """x support points for model density plot"""
         _xmin, _xmax = self.x_range
-        return np.linspace(_xmin, _xmax, self._n_plot_points_model_density)
+        return np.linspace(_xmin, _xmax, self.n_plot_points)
 
     @property
     def model_density_y(self):

--- a/kafe2/fit/indexed/plot.py
+++ b/kafe2/fit/indexed/plot.py
@@ -26,6 +26,7 @@ class IndexedPlotAdapter(PlotAdapterBase):
         :param fit_object: an :py:obj:`~kafe2.fit.indexed.IndexedFit` object
         """
         super(IndexedPlotAdapter, self).__init__(fit_object=indexed_fit_object)
+        self.x_range = (-0.5, self._fit.data_size - 0.5)
 
     @property
     def data_x(self):
@@ -66,16 +67,6 @@ class IndexedPlotAdapter(PlotAdapterBase):
     def model_yerr(self):
         """y error bars for model: ``None`` for :py:obj:`IndexedPlotContainer`"""
         return None #self.fit.model_error
-
-    @property
-    def x_range(self):
-        """x plot range: (-0.5, N-0.5) for :py:obj:`IndexedPlotContainer`"""
-        return (-0.5, self._fit.data_size - 0.5)
-
-    @property
-    def y_range(self):
-        """y plot range: ``None`` for :py:obj:`IndexedPlotContainer`"""
-        return None  # no fixed range
 
     # public methods
 

--- a/kafe2/fit/unbinned/plot.py
+++ b/kafe2/fit/unbinned/plot.py
@@ -25,15 +25,13 @@ class UnbinnedPlotAdapter(PlotAdapterBase):
     )
     del PLOT_SUBPLOT_TYPES['model']  # don't show "model" points
 
-    def __init__(self, unbinned_fit_object, n_plot_points_model=100):
+    def __init__(self, unbinned_fit_object):
         """
         Construct an :py:obj:`UnbinnedPlotAdapter` for a :py:obj:`~kafe2.fit.unbinned.UnbinnedFit` object:
         :param unbinned_fit_object: an :py:obj:`~kafe2.fit.unbinned.UnbinnedFit` object
-        :param n_plot_points_model: Number of data points for plotting the model
-        :type n_plot_points_model: int
         """
         super(UnbinnedPlotAdapter, self).__init__(fit_object=unbinned_fit_object)
-        self._n_plot_points_model = n_plot_points_model
+        self.n_plot_points = 100 if len(self.data_x) < 100 else len(self.data_x)
         self.x_range = self._compute_plot_range_x()
         self.y_range = self._compute_plot_range_y()
 
@@ -107,7 +105,7 @@ class UnbinnedPlotAdapter(PlotAdapterBase):
     def model_line_x(self):
         """x support values for model function"""
         _xmin, _xmax = self.x_range
-        return np.linspace(_xmin, _xmax, self._n_plot_points_model)
+        return np.linspace(_xmin, _xmax, self.n_plot_points)
 
     @property
     def model_line_y(self):

--- a/kafe2/fit/xy/plot.py
+++ b/kafe2/fit/xy/plot.py
@@ -32,7 +32,7 @@ class XYPlotAdapter(PlotAdapterBase):
     )
     del PLOT_SUBPLOT_TYPES['model']  # don't plot model xy points
 
-    def __init__(self, xy_fit_object, n_plot_points_model=100):
+    def __init__(self, xy_fit_object):
         """
         Construct an :py:obj:`XYPlotContainer` for a :py:obj:`~kafe2.fit.xy.XYFit` object:
 
@@ -40,8 +40,7 @@ class XYPlotAdapter(PlotAdapterBase):
         :type xy_fit_object: :py:class:`~kafe2.fit.xy.XYFit`
         """
         super(XYPlotAdapter, self).__init__(fit_object=xy_fit_object)
-        self._n_plot_points_model = n_plot_points_model
-
+        self.n_plot_points = 100 if len(self.data_x) < 50 else 2*len(self.data_x)
         self.x_range = self._compute_plot_range_x()
 
     # -- private methods
@@ -100,7 +99,7 @@ class XYPlotAdapter(PlotAdapterBase):
     def model_line_x(self):
         """x support values for model function"""
         _xmin, _xmax = self.x_range
-        return np.linspace(_xmin, _xmax, self._n_plot_points_model)
+        return np.linspace(_xmin, _xmax, self.n_plot_points)
 
     @property
     def model_line_y(self):

--- a/kafe2/fit/xy/plot.py
+++ b/kafe2/fit/xy/plot.py
@@ -42,7 +42,7 @@ class XYPlotAdapter(PlotAdapterBase):
         super(XYPlotAdapter, self).__init__(fit_object=xy_fit_object)
         self._n_plot_points_model = n_plot_points_model
 
-        self._plot_range_x = None
+        self.x_range = self._compute_plot_range_x()
 
     # -- private methods
 
@@ -51,10 +51,8 @@ class XYPlotAdapter(PlotAdapterBase):
             additional_pad = (0, 0)
         _xmin, _xmax = self._fit.x_range
         _w = _xmax - _xmin
-        self._plot_range_x = (
-            0.5 * (_xmin + _xmax - _w * pad_coeff) - additional_pad[0],
-            0.5 * (_xmin + _xmax + _w * pad_coeff) + additional_pad[1]
-        )
+        return (0.5 * (_xmin + _xmax - _w * pad_coeff) - additional_pad[0],
+                0.5 * (_xmin + _xmax + _w * pad_coeff) + additional_pad[1])
 
     # -- public properties
 
@@ -108,18 +106,6 @@ class XYPlotAdapter(PlotAdapterBase):
     def model_line_y(self):
         """y values at support points for model function"""
         return self._fit.eval_model_function(x=self.model_line_x)
-
-    @property
-    def x_range(self):
-        """x plot range"""
-        if self._plot_range_x is None:
-            self._compute_plot_range_x()
-        return self._plot_range_x
-
-    @property
-    def y_range(self):
-        """y plot range: ``None`` for :py:obj:`XYPlotContainer`"""
-        return None
 
     @property
     def y_error_band(self):

--- a/kafe2/test/fit/test_fit_xy.py
+++ b/kafe2/test/fit/test_fit_xy.py
@@ -92,24 +92,6 @@ class TestXYFitBasicInterface(AbstractTestFit, unittest.TestCase):
             y_data=self._ref_y_data,
             y_model=self._nominal_fit_result_y_model,
         )
-        self._nominal_fit_result_y_error_band = np.array([
-            0.78624539, 0.75683061, 0.72851823, 0.70133553, 0.67531087, 0.65047349,
-            0.62685308, 0.6044793 , 0.58338118, 0.56358629, 0.54511986, 0.52800367,
-            0.51225489, 0.49788481, 0.48489754, 0.47328885, 0.46304509, 0.45414241,
-            0.44654631, 0.44021158, 0.43508272, 0.43109475, 0.42817442, 0.42624171,
-            0.42521152, 0.42499547, 0.4255036 , 0.426646  , 0.42833427, 0.43048265,
-            0.43300903, 0.43583559, 0.43888936, 0.44210242, 0.44541208, 0.44876086,
-            0.4520964 , 0.45537126, 0.45854275, 0.46157262, 0.46442689, 0.46707555,
-            0.46949231, 0.47165442, 0.47354242, 0.47513997, 0.4764337 , 0.47741308,
-            0.47807029, 0.47840018, 0.47840018, 0.47807029, 0.47741308, 0.4764337 ,
-            0.47513997, 0.47354242, 0.47165442, 0.46949231, 0.46707555, 0.46442689,
-            0.46157262, 0.45854275, 0.45537126, 0.4520964 , 0.44876086, 0.44541208,
-            0.44210242, 0.43888936, 0.43583559, 0.43300903, 0.43048265, 0.42833427,
-            0.426646  , 0.4255036 , 0.42499547, 0.42521152, 0.42624171, 0.42817442,
-            0.43109475, 0.43508272, 0.44021158, 0.44654631, 0.45414241, 0.46304509,
-            0.47328885, 0.48489754, 0.49788481, 0.51225489, 0.52800367, 0.54511986,
-            0.56358629, 0.58338118, 0.6044793 , 0.62685308, 0.65047349, 0.67531087,
-            0.70133553, 0.72851823, 0.75683061, 0.78624539])
 
         # helper dict with all reference property values
         self._ref_prop_dict = dict(
@@ -214,8 +196,6 @@ class TestXYFitBasicInterface(AbstractTestFit, unittest.TestCase):
                 model=self._nominal_fit_result_xy_model,
                 did_fit=True,
                 cost_function_value=self._nominal_fit_result_cost,
-                # FIXME: remove hard coding
-                y_error_band=self._nominal_fit_result_y_error_band,
             ),
             call_before_fit=lambda f: f.do_fit(),
             rtol=1e-2
@@ -277,10 +257,6 @@ class TestXYFitBasicInterface(AbstractTestFit, unittest.TestCase):
             self._get_fit().set_poi_values(param_values=(1,))
         with self.assertRaises(XYFitException):
             self._get_fit().set_poi_values(param_values=(1,2,3,4,5))
-
-    def test_y_error_band_before_fit_raise(self):
-        with self.assertRaises(XYFitException):
-            self._get_fit().y_error_band
 
     def test_parameter_defaults(self):
         def dummy_model(x, a, b, c):
@@ -576,8 +552,6 @@ class TestXYFitWithSimpleYErrors(AbstractTestFit, unittest.TestCase):
                 model=self._nominal_fit_result_xy_model,
                 did_fit=True,
                 cost_function_value=self._nominal_fit_result_cost,
-                # FIXME: remove hard coding
-                y_error_band=self._nominal_fit_result_y_error_band,
             ),
             fit_names=['default', 'two_errors'],
             call_before_fit=lambda f: f.do_fit(),
@@ -720,8 +694,6 @@ class TestXYFitWithMatrixErrors(AbstractTestFit, unittest.TestCase):
                 model=self._nominal_fit_result_xy_model,
                 did_fit=True,
                 cost_function_value=self._nominal_fit_result_cost,
-                # FIXME: remove hard coding
-                y_error_band=self._nominal_fit_result_y_error_band,
             ),
             fit_names=['default', 'cor_matrix_and_error_vector',
                        'one_matrix_one_simple_error', 'two_matrix_errors'],


### PR DESCRIPTION
* [x] add plot_range setter in plot adapter classes, closes #114 #85 
* [x] think of a way to access them via the Plot class
* [x] fix ratio plot being changed by y_range modifications
* [x] add ability to set the support points for the model manually or always use 2x the amount of data but 100 points at least, would fix #25 
* ~~add ability to change limits for the contours profiler~~. This is already possible with the `profile_bound` parameter when constructing a ContoursProfiler 

In order to set the plot range and the support points for plotting the model and error band, I moved the calculation of the y_error_band from the XYFit to the plot adapter. Another way would be to add a support point kwarg to the method inside the XYFit. But I feel like calculating the y_error_band is part of the plotting methods and should be moved there anyways. How do you feel about this @dsavoiu and @JohannesGaessler?
Any other regarding the other changes would be appreciated as well.