### PR TITLE
Implemented alternative hist model bin evaluation

### DIFF
--- a/kafe2/fit/histogram/fit.py
+++ b/kafe2/fit/histogram/fit.py
@@ -38,18 +38,27 @@ class HistFit(FitBase):
                  model_density_function=function_library.normal_distribution_pdf,
                  cost_function=HistCostFunction_NegLogLikelihood(
                     data_point_distribution='poisson'),
-                 model_density_antiderivative=None,
+                 bin_evaluation="simpson",
                  minimizer=None,
                  minimizer_kwargs=None):
         """
-        Construct a fit of a model to a histogram.
+        Construct a fit of a model to a histogram. If bin_evaluation is a Python function or
+        of a numpy.vectorize object it is interpreted as the antiderivative of
+        model_density_function. If bin_evaluation is equal to "rectangle", "midpoint", "trapezoid",
+        or "simpson" the bin heights are evaluated according to the corresponding quadrature
+        formula. If bin_evaluation is equal to "numerical" the bin heights are evaluated by
+        numerically integrating model_density_function.
 
         :param data: a :py:class:`~kafe2.fit.hist.HistContainer` representing histogrammed data
         :type data: :py:class:`~kafe2.fit.hist.HistContainer`
         :param model_density_function: the model density function
-        :type model_density_function: :py:class:`~kafe2.fit.hist.HistModelFunction` or unwrapped native Python function
+        :type model_density_function: :py:class:`~kafe2.fit.hist.HistModelFunction` or unwrapped
+        native Python function
         :param cost_function: the cost function
-        :type cost_function: :py:class:`~kafe2.fit._base.CostFunctionBase`-derived or unwrapped native Python function
+        :type cost_function: :py:class:`~kafe2.fit._base.CostFunctionBase`-derived or unwrapped
+        native Python function
+        :param bin_evaluation: how the model evaluates bin heights.
+        :type bin_evaluation: str, callable, or numpy.vectorize
         :param minimizer: the minimizer to use for fitting.
         :type minimizer: None, "iminuit", "tminuit", or "scipy".
         :param minimizer_kwargs: dictionary with kwargs for the minimizer.
@@ -57,14 +66,10 @@ class HistFit(FitBase):
         """
         # set/construct the model function object
         if isinstance(model_density_function, self.__class__.MODEL_FUNCTION_TYPE):
-            # TODO shouldn't this Exception only be raised if the kafe2 model function already has an antiderivative?
-            if model_density_antiderivative is not None:
-                raise HistFitException("Antiderivative (%r) provided in constructor for %r, "
-                                       "but histogram model function object (%r) already constructed!"
-                                       % (model_density_antiderivative, self.__class__, model_density_function))
             self._model_function = model_density_function
         else:
-            self._model_function = self.__class__.MODEL_FUNCTION_TYPE(model_density_function, model_density_antiderivative=model_density_antiderivative)
+            self._model_function = self.__class__.MODEL_FUNCTION_TYPE(model_density_function)
+        self._bin_evaluation = bin_evaluation
 
         # validate the model function for this fit
         self._validate_model_function_for_fit_raise()
@@ -237,13 +242,10 @@ class HistFit(FitBase):
 
     def _set_new_parametric_model(self):
         # create the child ParametricModel object
-        self._param_model = self._new_parametric_model(self._data_container.size,
-                                                       self._data_container.bin_range,
-                                                       self._model_function,
-                                                       self.parameter_values,
-                                                       self._data_container.bin_edges,
-                                                       model_density_func_antiderivative=
-                                                       self._model_function.antiderivative)
+        self._param_model = self._new_parametric_model(
+            self._data_container.size, self._data_container.bin_range, self._model_function,
+            self.parameter_values, self._data_container.bin_edges,
+            bin_evaluation=self._bin_evaluation)
         self._param_model._on_error_change_callbacks = [self._on_error_change]
 
     # -- public properties

--- a/kafe2/fit/histogram/model.py
+++ b/kafe2/fit/histogram/model.py
@@ -1,7 +1,9 @@
 import numpy as np
 import six
+from scipy import integrate
+from inspect import getsource
 
-from .._base import ParametricModelBaseMixin, ModelFunctionBase, ModelFunctionException, ParameterFormatter
+from .._base import ParametricModelBaseMixin, ModelFunctionBase, ModelFunctionException
 from .container import HistContainer, HistContainerException
 from ..util import function_library
 
@@ -22,51 +24,15 @@ class HistModelFunctionException(ModelFunctionException):
 class HistModelFunction(ModelFunctionBase):
     EXCEPTION_TYPE = HistModelFunctionException
 
-    def __init__(self, model_density_function=None, model_density_antiderivative=None):
+    def __init__(self, model_density_function=None):
         """
         Construct :py:class:`XYModelFunction` object (a wrapper for a native Python function):
 
         :param model_density_function: function handle
-        :param model_density_antiderivative: function handle for model density antiderivative
         """
         # TODO: default model function
-        super(HistModelFunction, self).__init__(model_function=model_density_function, independent_argcount=1)
-
-        # special handling of numpy vectorized antiderivative functions
-        if isinstance(model_density_antiderivative, np.vectorize):
-            self._antiderivative = model_density_antiderivative
-            self._antiderivative_function_handle = model_density_antiderivative.pyfunc
-
-        # handle generic callables and `None`
-        elif callable(model_density_antiderivative) or model_density_antiderivative is None:
-            self._antiderivative_function_handle = model_density_antiderivative
-            self._antiderivative = self._antiderivative_function_handle
-
-        # raise if not callable
-        else:
-            raise ModelFunctionException("Cannot use {} as model density antiderivative: "
-                                         "object not callable!".format(model_density_antiderivative))
-
-        self._validate_model_function_antiderivative_raise()
-
-    def _validate_model_function_antiderivative_raise(self):
-        if self.antiderivative is None:
-            return
-
-        _antider_parameters = list(signature(self._antiderivative_function_handle).parameters)
-        _model_func_parameters = list(self.signature.parameters)
-
-        # require antiderivative and density to have the same arguments
-        if _model_func_parameters != _antider_parameters:
-            raise self.__class__.EXCEPTION_TYPE(
-                "Model density function and its antiderivative require the same argument structures:"
-                "(%r vs %r)"
-                % (_model_func_parameters, _antider_parameters))
-
-    @property
-    def antiderivative(self):
-        """model density antiderivative"""
-        return self._antiderivative
+        super(HistModelFunction, self).__init__(
+            model_function=model_density_function, independent_argcount=1)
 
 
 class HistParametricModelException(HistContainerException):
@@ -77,37 +43,92 @@ class HistParametricModel(ParametricModelBaseMixin, HistContainer):
     #TODO n_bins, bin_range, bin_edges contain redundant information, should the arguments for HistParametricModel be refactored?
     def __init__(self, n_bins, bin_range,
                  model_density_func=function_library.normal_distribution_pdf,
-                 model_parameters=[1.0, 1.0], bin_edges=None, model_density_func_antiderivative=None):
-        # print "IndexedParametricModel.__init__(model_func=%r, model_parameters=%r)" % (model_func, model_parameters)
-        self._model_density_func_antider_handle = model_density_func_antiderivative
-        super(HistParametricModel, self).__init__(model_density_func, model_parameters, n_bins, bin_range,
-                                                  bin_edges=bin_edges, fill_data=None, dtype=float)
+                 model_parameters=[1.0, 1.0], bin_edges=None, bin_evaluation="simpson"):
+        super(HistParametricModel, self).__init__(
+            model_density_func, model_parameters, n_bins, bin_range,
+            bin_edges=bin_edges, fill_data=None, dtype=float)
+        self._bin_evaluation = bin_evaluation
+        if isinstance(self._bin_evaluation, str):
+            self._bin_evaluation = self._bin_evaluation.lower()
+            self._bin_evaluation_string = self._bin_evaluation
+            if self._bin_evaluation in ("rectangle", "midpoint"):
+                self._bin_evaluation_method = self._bin_evaluation_rectangle
+            elif self._bin_evaluation == "trapezoid":
+                self._bin_evaluation_method = self._bin_evaluation_trapezoid
+            elif self._bin_evaluation == "simpson":
+                self._bin_evaluation_method = self._bin_evaluation_simpson
+            elif self._bin_evaluation == "numerical":
+                self._bin_evaluation_method = self._bin_evaluation_numerical
+            else:
+                raise ValueError("Unknown bin evaluation method: %s" % self._bin_evaluation)
+        else:
+            if isinstance(self._bin_evaluation, np.vectorize):
+                # special handling of numpy vectorized antiderivative functions
+                _antiderivative_function_handle = self._bin_evaluation.pyfunc
+            elif callable(self._bin_evaluation):
+                # handle generic callables
+                _antiderivative_function_handle = self._bin_evaluation
+            else:
+                # raise if not string and not callable
+                raise ValueError(
+                    "Cannot use {} as bin evaluation method: not a string and not callable!".format(
+                        self._bin_evaluation))
+
+            # Retrieving source code will fail if the function was generated through exec.
+            # For kafe2go self._bin_evaluation_string will be replaced.
+            try:
+                self._bin_evaluation_string = getsource(_antiderivative_function_handle)
+            except OSError:
+                self._bin_evaluation_string = "OSError"
+            except IOError:
+                self._bin_evaluation_string = "IOError"
+            _antider_parameters = list(signature(_antiderivative_function_handle).parameters)
+            if isinstance(self._model_function_object, HistModelFunction):
+                _model_func_parameters = list(self._model_function_object.signature.parameters)
+            else:
+                _model_func_parameters = list(signature(self._model_function_object).parameters)
+
+            # require antiderivative and density to have the same arguments
+            if _model_func_parameters != _antider_parameters:
+                raise ValueError(
+                    "Model density function and its antiderivative have different argument "
+                    "signatures: (%r vs %r)"
+                    % (_model_func_parameters, _antider_parameters))
+            self._bin_evaluation_method = self._bin_evaluation_antiderivative
 
     # -- private methods
 
-    def _eval_model_func_density_integral_over_bins(self):
-        _as = self._bin_edges[:-1]
-        _bs = self._bin_edges[1:]
-        assert len(_as) == len(_bs) == self.size
-        if self._model_density_func_antider_handle is not None:
-            _fval_antider_as = self._model_density_func_antider_handle(_as, *self._model_parameters)
-            _fval_antider_bs = self._model_density_func_antider_handle(_bs, *self._model_parameters)
-            assert len(_fval_antider_as) == len(_fval_antider_bs) == self.size
-            _int_val = np.asarray(_fval_antider_bs) - np.asarray(_fval_antider_as)
-        else:
-            import scipy.integrate as integrate
-            _integrand_func = lambda x: self._model_function_object(x, *self._model_parameters)
-            # TODO: find more efficient alternative
-            _int_val = np.zeros(self.size)
-            for _i, (_a, _b) in enumerate(zip(_as, _bs)):
-                _int_val[_i], _ = integrate.quad(_integrand_func, _a, _b)
-        return _int_val
-
     def _recalculate(self):
         # don't use parent class setter for 'data' -> set directly
-        self._data[1:-1] = self._eval_model_func_density_integral_over_bins()
+        self._data[1:-1] = self._bin_evaluation_method()
         self._pm_calculation_stale = False
 
+    def _bin_evaluation_rectangle(self):
+        _height_centers = self._model_function_object(self.bin_centers, *self._model_parameters)
+        return self.bin_widths * _height_centers
+
+    def _bin_evaluation_trapezoid(self):
+        _height_edges = self._model_function_object(self._bin_edges, *self._model_parameters)
+        return self.bin_widths / 2.0 * (_height_edges[:-1] + _height_edges[1:])
+
+    def _bin_evaluation_simpson(self):
+        _height_edges = self._model_function_object(self._bin_edges, *self._model_parameters)
+        _height_centers = self._model_function_object(self.bin_centers, *self._model_parameters)
+        return self.bin_widths / 6.0 * (
+                _height_edges[:-1] + 4.0 * _height_centers + _height_edges[1:])
+
+    def _bin_evaluation_numerical(self):
+        _integrand_func = lambda x: self._model_function_object(x, *self._model_parameters)
+        _int_val = np.zeros(self.size)
+        for _i, (_a, _b) in enumerate(zip(self._bin_edges[:-1], self._bin_edges[1:])):
+            _int_val[_i], _ = integrate.quad(_integrand_func, _a, _b)
+        return _int_val
+
+    def _bin_evaluation_antiderivative(self):
+        _fval_antider_as = self._bin_evaluation(self._bin_edges[:-1], *self._model_parameters)
+        _fval_antider_bs = self._bin_evaluation(self._bin_edges[1:], *self._model_parameters)
+        assert len(_fval_antider_as) == len(_fval_antider_bs) == self.size
+        return np.asarray(_fval_antider_bs) - np.asarray(_fval_antider_as)
 
     # -- public properties
 
@@ -121,6 +142,22 @@ class HistParametricModel(ParametricModelBaseMixin, HistContainer):
     @data.setter
     def data(self, new_data):
         raise HistParametricModelException("Parametric model data cannot be set!")
+
+    @property
+    def bin_evaluation(self):
+        """
+        :return: how the model evaluates bin heights.
+        :rtype str, callable, or numpy.vectorize
+        """
+        return self._bin_evaluation
+
+    @property
+    def bin_evaluation_string(self):
+        """
+        :return: string representation of how the model evaluates bin heights.
+        :rtype str
+        """
+        return self._bin_evaluation_string
 
     # -- public methods
 

--- a/kafe2/fit/representation/_yaml_base.py
+++ b/kafe2/fit/representation/_yaml_base.py
@@ -57,6 +57,9 @@ class YamlReaderMixin(DReprReaderMixin):
             yaml_doc = cls._process_string(yaml_doc, default_type)
         _overriden_yaml_doc = cls._check_required_keywords_and_override_subspaces(yaml_doc, default_type, modify_kwargs)
         _object, _leftover_yaml_doc = cls._convert_yaml_doc_to_object(_overriden_yaml_doc.copy())
+        for _keyword in cls._get_ignored_if_none_keywords():
+            if _keyword in _leftover_yaml_doc and _leftover_yaml_doc[_keyword] is None:
+                _leftover_yaml_doc.pop(_keyword, None)
         if _leftover_yaml_doc:
             raise YamlReaderException("Received unknown or unsupported keywords for constructing a %s object: %s"
                                       % (cls.BASE_OBJECT_TYPE_NAME, list(_leftover_yaml_doc.keys())))
@@ -118,7 +121,11 @@ class YamlReaderMixin(DReprReaderMixin):
     @classmethod
     def _get_required_keywords(cls, yaml_doc, kafe_object_class):
         return []
-    
+
+    @classmethod
+    def _get_ignored_if_none_keywords(cls):
+        return []
+
     @classmethod
     def _convert_yaml_doc_to_object(cls, yaml_doc):
         return None, None #format: return <kafe2 object>, <leftover yaml doc>

--- a/kafe2/fit/representation/fit/yaml_drepr.py
+++ b/kafe2/fit/representation/fit/yaml_drepr.py
@@ -196,7 +196,6 @@ class FitYamlReader(YamlReaderMixin, FitDReprBase):
             _fit_object = HistFit(
                 data=_data,
                 model_density_function=_read_model_function,
-                model_density_antiderivative=None,
                 minimizer=_minimizer,
                 minimizer_kwargs=_minimizer_kwargs
             )

--- a/kafe2/test/fit/test_fit_hist.py
+++ b/kafe2/test/fit/test_fit_hist.py
@@ -114,7 +114,7 @@ class TestHistFitBasicInterface(AbstractTestFit, unittest.TestCase):
 
         )
 
-    def _get_fit(self, model_density_function=None, model_density_antiderivative=None, cost_function=None):
+    def _get_fit(self, model_density_function=None, bin_evaluation="numerical", cost_function=None):
         '''convenience'''
 
         model_density_function = model_density_function or hist_model_density
@@ -126,7 +126,7 @@ class TestHistFitBasicInterface(AbstractTestFit, unittest.TestCase):
         _fit = HistFit(
             data=self._ref_hist_cont,
             model_density_function=model_density_function,
-            model_density_antiderivative=model_density_antiderivative,
+            bin_evaluation=bin_evaluation,
             cost_function=cost_function,
             minimizer=self.MINIMIZER
         )
@@ -140,9 +140,9 @@ class TestHistFitBasicInterface(AbstractTestFit, unittest.TestCase):
             #'default': \
             #    self._get_fit(),
             'explicit_chi2': \
-                self._get_fit(cost_function=simple_chi2, model_density_antiderivative=hist_model_density_antideriv),
+                self._get_fit(cost_function=simple_chi2, bin_evaluation=hist_model_density_antideriv),
             'model_with_antiderivative': \
-                self._get_fit(model_density_antiderivative=hist_model_density_antideriv),
+                self._get_fit(bin_evaluation=hist_model_density_antideriv),
         }
 
     def test_initial_state(self):
@@ -190,7 +190,7 @@ class TestHistFitBasicInterface(AbstractTestFit, unittest.TestCase):
         )
 
     def test_update_data(self):
-        _fit = self._get_fit(model_density_antiderivative=hist_model_density_antideriv)
+        _fit = self._get_fit(bin_evaluation=hist_model_density_antideriv)
 
         _new_entries = np.array([
             19.424357258680693, 19.759361803397155, 18.364336396273362, 18.36464562195573,
@@ -269,7 +269,7 @@ class TestHistFitBasicInterface(AbstractTestFit, unittest.TestCase):
         with self.assertRaises(HistModelFunctionException) as _exc:
             HistFit(data=self._ref_hist_cont,
                     model_density_function=dummy_model,
-                    model_density_antiderivative=dummy_model,
+                    bin_evaluation=dummy_model,
                     minimizer=self.MINIMIZER)
 
         self.assertIn(
@@ -283,7 +283,7 @@ class TestHistFitBasicInterface(AbstractTestFit, unittest.TestCase):
         with self.assertRaises(HistModelFunctionException) as _exc:
             HistFit(data=self._ref_hist_cont,
                     model_density_function=dummy_model,
-                    model_density_antiderivative=dummy_model,
+                    bin_evaluation=dummy_model,
                     minimizer=self.MINIMIZER)
 
         self.assertIn(
@@ -298,7 +298,7 @@ class TestHistFitBasicInterface(AbstractTestFit, unittest.TestCase):
         with self.assertRaises(HistModelFunctionException) as _exc:
             HistFit(data=self._ref_hist_cont,
                     model_density_function=dummy_model,
-                    model_density_antiderivative=dummy_model,
+                    bin_evaluation=dummy_model,
                     minimizer=self.MINIMIZER)
 
         self.assertIn('variable', _exc.exception.args[0])
@@ -312,7 +312,7 @@ class TestHistFitBasicInterface(AbstractTestFit, unittest.TestCase):
         with self.assertRaises(HistModelFunctionException) as _exc:
             HistFit(data=self._ref_hist_cont,
                     model_density_function=dummy_model,
-                    model_density_antiderivative=dummy_model,
+                    bin_evaluation=dummy_model,
                     minimizer=self.MINIMIZER)
 
         self.assertIn('variable', _exc.exception.args[0])
@@ -326,7 +326,7 @@ class TestHistFitBasicInterface(AbstractTestFit, unittest.TestCase):
         with self.assertRaises(HistModelFunctionException) as _exc:
             HistFit(data=self._ref_hist_cont,
                     model_density_function=dummy_model,
-                    model_density_antiderivative=dummy_model,
+                    bin_evaluation=dummy_model,
                     minimizer=self.MINIMIZER)
 
         self.assertIn('variable', _exc.exception.args[0])
@@ -335,20 +335,17 @@ class TestHistFitBasicInterface(AbstractTestFit, unittest.TestCase):
         #self.assertIn('varkwargs', _exc.exception.args[0])
 
     def test_model_and_antiderivative_different_signatures_raise(self):
-        def dummy_model(x, data):
+        def dummy_model(x, mu, sigma):
             pass
 
-        def dummy_model_antiderivative(x, bogus):
+        def dummy_model_antiderivative(x, mu, bogus):
             pass
 
-        with self.assertRaises(HistModelFunctionException) as _exc:
+        with self.assertRaises(ValueError) as _exc:
             HistFit(data=self._ref_hist_cont,
                     model_density_function=dummy_model,
-                    model_density_antiderivative=dummy_model_antiderivative,
+                    bin_evaluation=dummy_model_antiderivative,
                     minimizer=self.MINIMIZER)
-
-        self.assertIn('require the same argument structures', _exc.exception.args[0])
-        self.assertIn('data', _exc.exception.args[0])
 
     def test_model_and_antiderivative_no_defaults(self):
         def legendre_grade_2(x, a=1, b=2, c=3):
@@ -360,20 +357,20 @@ class TestHistFitBasicInterface(AbstractTestFit, unittest.TestCase):
         # should not raise an error
         HistFit(data=self._ref_hist_cont,
                 model_density_function=legendre_grade_2,
-                model_density_antiderivative=legendre_grade_2_integrated,
+                bin_evaluation=legendre_grade_2_integrated,
                 minimizer=self.MINIMIZER)
 
     def test_report_before_fit(self):
         # TODO: check report content
         _buffer = six.StringIO()
-        _fit = self._get_fit(model_density_antiderivative=hist_model_density_antideriv)
+        _fit = self._get_fit(bin_evaluation=hist_model_density_antideriv)
         _fit.report(output_stream=_buffer)
         self.assertNotEqual(_buffer.getvalue(), "")
 
     def test_report_after_fit(self):
         # TODO: check report content
         _buffer = six.StringIO()
-        _fit = self._get_fit(model_density_antiderivative=hist_model_density_antideriv)
+        _fit = self._get_fit(bin_evaluation=hist_model_density_antideriv)
         _fit.do_fit()
         _fit.report(output_stream=_buffer)
         self.assertNotEqual(_buffer.getvalue(), "")

--- a/kafe2/test/fit/test_fit_multi.py
+++ b/kafe2/test/fit/test_fit_multi.py
@@ -92,7 +92,7 @@ class TestMultiFit(unittest.TestCase):
                 bin_range=(1.5, 3.5),
                 fill_data=fill_data
             ),
-            model_density_antiderivative=TestMultiFit._norm_cdf,
+            bin_evaluation=TestMultiFit._norm_cdf,
             minimizer=minimizer
         )
 

--- a/kafe2/test/fit/test_fits_with_parameter_constraints.py
+++ b/kafe2/test/fit/test_fits_with_parameter_constraints.py
@@ -67,7 +67,7 @@ class TestParameterConstraintInHistFit(unittest.TestCase):
         self._test_par_res = np.transpose(self._test_par_res, axes=(0, 2, 1))
 
         self._fit_no_constraints = HistFit(self._data_container, model_density_function=self._model_function,
-                                           model_density_antiderivative=self._model_function_antiderivative)
+                                           bin_evaluation=self._model_function_antiderivative)
         self._fit_no_constraints.do_fit()
         _cost_function = self._fit_no_constraints._fitter._fcn_wrapper
         self._profile_no_constraints = np.zeros((4, 9))
@@ -79,7 +79,7 @@ class TestParameterConstraintInHistFit(unittest.TestCase):
 
     def test_bad_input_exception(self):
         _fit_with_constraint = HistFit(self._data_container, model_density_function=self._model_function,
-                                       model_density_antiderivative=self._model_function_antiderivative)
+                                       bin_evaluation=self._model_function_antiderivative)
         with self.assertRaises(HistFitException):
             _fit_with_constraint.add_parameter_constraint('c', 1.0, 1.0)
         with self.assertRaises(HistFitException):
@@ -89,30 +89,30 @@ class TestParameterConstraintInHistFit(unittest.TestCase):
 
     def test_fit_profile_cov_mat_uncorrelated(self):
         _fit_with_constraint = HistFit(self._data_container, model_density_function=self._model_function,
-                                       model_density_antiderivative=self._model_function_antiderivative)
+                                       bin_evaluation=self._model_function_antiderivative)
         _fit_with_constraint.add_matrix_parameter_constraint(['a', 'b'], self._means, self._cov_mat_uncor)
         self._test_consistency(_fit_with_constraint, self._cov_mat_uncor_inv)
         _fit_with_constraint_alt = HistFit(self._data_container, model_density_function=self._model_function,
-                                           model_density_antiderivative=self._model_function_antiderivative)
+                                           bin_evaluation=self._model_function_antiderivative)
         _fit_with_constraint_alt.add_parameter_constraint('a', self._means[0], np.sqrt(self._vars[0]))
         _fit_with_constraint_alt.add_parameter_constraint('b', self._means[1], np.sqrt(self._vars[1]))
         self._test_consistency(_fit_with_constraint_alt, self._cov_mat_uncor_inv)
 
     def test_fit_profile_cov_mat_correlated(self):
         _fit_with_constraint = HistFit(self._data_container, model_density_function=self._model_function,
-                                       model_density_antiderivative=self._model_function_antiderivative)
+                                       bin_evaluation=self._model_function_antiderivative)
         _fit_with_constraint.add_matrix_parameter_constraint(['a', 'b'], self._means, self._cov_mat_cor)
         self._test_consistency(_fit_with_constraint, self._cov_mat_cor_inv)
 
     def test_fit_profile_simple_a(self):
         _fit_with_constraint = HistFit(self._data_container, model_density_function=self._model_function,
-                                       model_density_antiderivative=self._model_function_antiderivative)
+                                       bin_evaluation=self._model_function_antiderivative)
         _fit_with_constraint.add_parameter_constraint('a', self._means[0], np.sqrt(self._vars[0]))
         self._test_consistency(_fit_with_constraint, self._cov_mat_simple_a_inv)
 
     def test_fit_profile_simple_b(self):
         _fit_with_constraint = HistFit(self._data_container, model_density_function=self._model_function,
-                                       model_density_antiderivative=self._model_function_antiderivative)
+                                       bin_evaluation=self._model_function_antiderivative)
         _fit_with_constraint.add_parameter_constraint('b', self._means[1], np.sqrt(self._vars[1]))
         self._test_consistency(_fit_with_constraint, self._cov_mat_simple_b_inv)
 

--- a/kafe2/test/fit/test_representers_fit_yaml.py
+++ b/kafe2/test/fit/test_representers_fit_yaml.py
@@ -151,7 +151,6 @@ TEST_FIT_HIST_EXTRA_KEYWORD = TEST_FIT_HIST + """
 extra_keyword: 3.14
 """
 
-#FIXME something goes wrong when constructing the parametric model
 TEST_FIT_HIST_SIMPLE="""
 type: histogram
 n_bins: 8
@@ -214,19 +213,25 @@ class TestHistFitYamlRepresenter(unittest.TestCase, AbstractTestFitRepresenter):
         self._test_parameters_default_simple = np.array([1.0, 1.0])
         self._test_parameters = np.array([0.2, 0.5])
         self._test_bin_range = (-2.0, 2.0)
-        self._test_parameters_do_fit = np.array([2.0117809129092095, -1.090410559090481])
+        self._test_parameters_do_fit = np.array([0.2028599998043365, 0.5011616918536066])
+        self._test_parameters_do_fit_simple = np.array([0.20031512887278155, 0.4967236106961646])
         self._test_x = np.array([-2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0])
         self._test_density_default = self.hist_model_density(self._test_x, *self._test_parameters_default)
         self._test_density_default_simple = self.hist_model_density(self._test_x, *self._test_parameters_default_simple)
-        self._test_density_do_fit = self.hist_model_density(self._test_x, *self._test_parameters)
-        
+        self._test_density_do_fit = self.hist_model_density(self._test_x, *self._test_parameters_do_fit)
+        self._test_density_do_fit_simple = self.hist_model_density(self._test_x, *self._test_parameters_do_fit_simple)
+
         _data = HistContainer(n_bins=self._test_n_bins, bin_range=self._test_bin_range, fill_data=self._test_raw_data)
         self._fit = HistFit(
             data=_data,
             model_density_function=TestHistFitYamlRepresenter.hist_model_density
         )
         self._fit.add_error(err_val=0.1)
-        
+        self._fit.add_parameter_constraint("mu", 0.1, 1.0)
+        self._fit.add_parameter_constraint("sigma", 1.0, 0.5)
+        self._fit.add_matrix_parameter_constraint(
+            ["sigma", "mu"], [1.3, 2.5], [[1.1, 0.1], [0.1, 2.4]])
+
         self.setup_streams()
 
     def test_read_from_testfile_stream(self):
@@ -246,21 +251,19 @@ class TestHistFitYamlRepresenter(unittest.TestCase, AbstractTestFitRepresenter):
         )
         
         _read_fit.do_fit()
-        
-        #FIXME fit results are wrong
-        #self.assertTrue(
-        #    np.allclose(
-        #        self._test_parameters_do_fit,
-        #        _read_fit.parameter_values
-        #    )
-        #)
-        #self.assertTrue(
-        #    True or
-        #    np.allclose(
-        #        self._test_density_do_fit,
-        #        _read_fit.eval_model_function_density(self._test_x)
-        #    )
-        #)
+        self.assertTrue(
+            np.allclose(
+                self._test_parameters_do_fit,
+                _read_fit.parameter_values
+            )
+        )
+        self.assertTrue(
+            True or
+            np.allclose(
+                self._test_density_do_fit,
+                _read_fit.eval_model_function_density(self._test_x)
+            )
+        )
 
     def test_read_from_testfile_stream_simple(self):
         _read_fit = self._testfile_streamreader_simple.read()
@@ -279,21 +282,19 @@ class TestHistFitYamlRepresenter(unittest.TestCase, AbstractTestFitRepresenter):
         )
         
         _read_fit.do_fit()
-        
-        #FIXME fit results are wrong
-        #self.assertTrue(
-        #    np.allclose(
-        #        self._test_parameters_do_fit,
-        #        _read_fit.parameter_values
-        #    )
-        #)
-        #self.assertTrue(
-        #    True or
-        #    np.allclose(
-        #        self._test_density_do_fit,
-        #        _read_fit.eval_model_function_density(self._test_x)
-        #    )
-        #)
+
+        self.assertTrue(
+            np.allclose(
+                self._test_parameters_do_fit_simple,
+                _read_fit.parameter_values
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                self._test_density_do_fit_simple,
+                _read_fit.eval_model_function_density(self._test_x)
+            )
+        )
 
     def test_round_trip_with_stringstream(self):
         self._roundtrip_streamwriter.write()
@@ -315,20 +316,19 @@ class TestHistFitYamlRepresenter(unittest.TestCase, AbstractTestFitRepresenter):
         )
         
         _read_fit.do_fit()
-        
-        #FIXME fit results are wrong
-        #self.assertTrue(
-        #    np.allclose(
-        #        self._test_parameters_do_fit,
-        #        _read_fit.parameter_values
-        #    )
-        #)
-        #self.assertTrue(
-        #    np.allclose(
-        #        self._test_density_do_fit,
-        #        _read_fit.eval_model_function_density(self._test_x)
-        #    )
-        #)
+
+        self.assertTrue(
+            np.allclose(
+                self._test_parameters_do_fit,
+                _read_fit.parameter_values
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                self._test_density_do_fit,
+                _read_fit.eval_model_function_density(self._test_x)
+            )
+        )
 
 
 TEST_FIT_INDEXED="""


### PR DESCRIPTION
Fixes https://github.com/dsavoiu/kafe2/issues/115 .

Histogram model bin heights can now be evaluated using quadratures.
To this end the model_density_func_antiderivative keyword has been replaced with the more general bin_evaluation keyword.
By default Simpson's rule is used.
The bin_evaluation is now separate from the hist model function; it's contained entirely in the hist parametric model.
Previously the antiderivative was validated in the model function but used in the parametric model.
I implemented some simple kafe2go legacy support for hist fits that were dumped with the old interface.